### PR TITLE
feat(query): PR A — verifiable provenance resolver + HTTP surface (extends #13)

### DIFF
--- a/ONTOLOGY_PHASE3_QUERY_LAYER_PLAN.md
+++ b/ONTOLOGY_PHASE3_QUERY_LAYER_PLAN.md
@@ -1,323 +1,623 @@
 # Phase 3 — The Query Layer: PR-by-PR Implementation Plan
 
-> Status tracker (update as PRs land):
-> - **PR 6** — query foundation + first compiled template — ✅ merged-pending (#13)
-> - **PR 7** — briefing/pre-consult query set — ⬜ not started
-> - **PR 8** — HTTP query API — ⬜ not started
-> - **PR 9** — narrow NL layer (ships disabled) — ⬜ not started
-> - **PR 10** — briefing_items + materialiser — ⬜ not started
-> - **PR 11** — invariant hardening + postmortem — ⬜ not started
+> **RE-DRAFT — provenance-verifiable-first ordering.** This supersedes the
+> earlier primitives→NL→provenance→standing sequence. The inversion is a
+> safety decision, not a preference: Phase 3's failure mode is a silent,
+> plausible-looking wrong answer with a provenance link beside it, and the
+> binding constraint (a clinician — or a prospecting doctor in a demo —
+> trusting it) is present from the first runnable query, not at customer
+> arrival.
 >
-> User decisions locked at planning time:
-> - Query shapes: use the plan's evidence-based set (confirmed)
-> - NL layer: build disabled, decide provider later (confirmed)
-> - Briefing UI: deferred to Phase 4 (confirmed)
-> - Scheduler / access-logging / clinical_query capability: ride the plan's
->   recommendation, verified in their respective PRs
+> **Status tracker (update as PRs land):**
+> - **PR A** — primitives + *verifiable* provenance (extends open PR #13) — ✅ code-complete, safety property verified on live data (Phase-0 probe iv + 46/46 tests), cleared to merge; browser-contrast carried to PR B
+> - **PR B** — hardening + briefing/pre-consult set + the ugly cases — ⬜ (carries the PR A browser openable-vs-unresolvable contrast as an un-skippable DoD item — see PR B scope)
+> - **PR C** — thinnest NL mapping (ships disabled) — ⬜
+> - **PR D** — standing-query materialisation + Phase 3 close-out — ⬜
+>
+> **Plan approved at review with two required changes (safety-property
+> reframe in three places; PR B sized-not-projected) and all four
+> reserved decisions LOCKED.** Both required changes are applied below;
+> the locked decisions are in "Decisions locked at review."
+>
+> **Disposition of open PR #13: DO NOT MERGE AS-IS — extend the branch to
+> meet PR A's bar before merge.** See the dedicated section below.
+>
+> **All decisions locked** (planning time: query-shape set, NL ships
+> disabled, briefing UI → Phase 4; at review: low-confidence phrasing,
+> reversed-source aggregate, unresolvable citation wording,
+> `clinical_query` out of foundation). See "Decisions locked at review."
 
 ---
 
 ## Context
 
-Phases 0–2 built the ontology spine (typed `Patient`/`Document`/`Consultation`
-objects, a link registry) and made every mutation a first-class audited
-`Action` flowing through `app/actions/executor.py` with a hard-won "thin
-Python orchestrator + PL/pgSQL RPC for the ACID/locking part" pattern.
-Phase 3 turns the spine load-bearing for *reads*: clinicians ask questions,
-get ranked answers, every answer carries its source document. The roadmap's
-four sub-goals (structured query primitives → narrow NL layer →
-provenance-in-every-answer → standing-query materialisation) are correctly
-sequenced but each is a different risk class. The empirical probe of the
-live DB changes the plan materially: clinical *write* tables are
-well-populated (67 patients, 79 encounters, 45 prescriptions, 24 diagnoses,
-`document_embeddings` already at 76 rows with an ivfflat index) but the lab
-corpus is effectively empty (1 `lab_results` row, `test_code` NULL, no
-LOINC), and `lab_results` has no `patient_id`/`workspace_id` (joins through
-`lab_orders`). The roadmap's flagship example query
-(`has_lab_result(loinc="4548-4", ...)`) is therefore aspirational against
-current data and must be planned as schema-correct-but-data-thin, not as
-the demo. supabase-py REST as `service_role` (RLS-bypassing) remains the
-only mutation/read path from Python; complex joins/aggregations/pgvector
-force PL/pgSQL RPCs or the psycopg2 `DATABASE_URL` path, exactly as in
-Phase 2.
+Phases 0–2 built the typed ontology spine and made every mutation a
+first-class audited `Action` through `app/actions/executor.py`. Phase 3
+turns the spine load-bearing for *reads*. The prior plan correctly
+identified that supabase-py's PostgREST builder cannot express the
+required joins, so the query layer is a compiler to tenant-scoped
+PL/pgSQL RPCs (proven in PR #13 / migration 024).
+
+The binding constraint is not customer count — it is the first runnable
+query. Phase 2's failure mode was loud (rollback, action error). Phase
+3's is silent and clinically consequential: the layer answers 20 queries
+correctly and returns a subtly wrong cohort on the 21st, with a plausible
+provenance link beside it, and nobody notices until a doctor acts on it.
+In the current pre-customer reality the *demo itself* is the binding
+constraint. Therefore provenance is not a UI feature — it is the
+correctness mechanism, and it must be **verifiable** (a resolvable
+`source_document_id` → an openable scan + a human-readable citation),
+not merely **present** (an opaque UUID in a JSONB blob), from the first
+query the system can run.
+
+**Precise statement of what verifiable provenance does and does not
+defend (review-required framing — do not soften this anywhere it
+recurs).** Verifiable provenance defends *one* failure exactly: the
+**dead-link** failure — a row presented authoritatively whose source
+silently resolves to nothing. That failure is measured, dominant (62%,
+finding #1), and this is the failure the whole ordering exists to close.
+What verifiable provenance does **not** defend is the **wrong-extraction**
+failure: a row whose `source_document_id` opens a real scan, but the
+ICD-10/medication/vital extracted *from* that scan is itself wrong.
+Verifiable provenance makes that failure *checkable by a motivated reader*
+— someone who opens the scan and confirms the extracted fact against the
+document. **A clinician in a hurry, and emphatically a prospecting doctor
+in a demo, is not a motivated reader.** The provenance link is the
+correctness mechanism *only when it is used*; an openable link beside a
+wrong extraction that nobody opens is still a confident wrong answer with
+a working "open" button. Phase 3 does not, and within its scope cannot,
+solve extraction correctness (that is upstream of the query layer and
+out of Phase 3 — attempting it here is scope-balloon). The honest
+boundary, stated here and re-stated identically in "What Phase 3 earns"
+and the close-out post-mortem: **the failure mode becomes a known unknown
+the clinician sees for dead links; for live links it becomes
+checkable-but-not-checked, which is a real residual risk, not a closed
+one.**
+
+**Empirical probe of the live dev DB (role=postgres) — five findings,
+three safety-load-bearing:**
+
+1. **The verifiability gap is present and dominant.** `digitised_documents`
+   has 20 rows. **15 of 24 diagnoses carrying a `source_document_id` point
+   at a document row that no longer exists** (the join returns NULL; IDs
+   survive in `action_audit_log.affected_objects`). PR #13's contract is
+   satisfied (UUID present) but a resolver produces a dead link / blank
+   citation for 62% of real rows while the answer still renders
+   authoritative. This is the unsafe artifact, and it is the *dominant*
+   case on the corpus, not a hypothetical.
+2. **No clinical fact table carries a per-row confidence column.** The
+   only confidence signal is `gp_validation_sessions.confidence_scores`,
+   **section-level not per-fact**, keyed by `document_id`, recoverable for
+   only **1 of 16** distinct diagnosis source documents.
+3. **"Source document reversed" does not currently manifest as a live
+   stale fact** — `reverse_action_promote_document` *DELETEs* the fact
+   rows. 17/100 promotions reversed, 0 live diagnoses point at a reversed
+   promotion. The risk is structural-future, not present-corpus.
+4. **"Two source documents" is absent** — 0 patients have diagnoses from
+   >1 source document.
+5. **Lab/vitals thinness confirmed** — 1 `lab_results` row (no LOINC), 5
+   `vitals` rows (2 with `bp_systolic>140`). `doc_type` is 0% populated,
+   so a citation cannot say "referral letter" — only `filename` +
+   `upload_date` + page.
 
 ## Design choices
 
-**1. The query layer is a compiler to PL/pgSQL RPCs, not an ORM over
-PostgREST.** The roadmap's example query spans Patient → Diagnosis (FK
-join) → LabResult (two-hop join through `lab_orders`) → ordering on a
-denormalised summary. supabase-py's PostgREST builder cannot express
-multi-table joins with per-branch filters, `EXISTS` sub-selects, or
-`embedding <=> $1` ordering. The established and *only proven* pattern
-(migrations 011, 015, 021, 022) is: a Python builder produces a structured
-query IR, a small set of parameterised PL/pgSQL `STABLE` functions execute
-it, the supabase client calls them via `.rpc()`. *Rejected alternative:*
-the direct psycopg2 `DATABASE_URL` path for ad-hoc SQL. It works (used for
-migrations) and bypasses RLS, but it (a) duplicates the connection/secrets
-surface inside request handlers, (b) makes the PR 5 AST tenant-guard blind
-(the guard only understands `supabase.table(...)` chains — raw psycopg2 SQL
-is invisible to it, so a missing `workspace_id` would not trip CI), and (c)
-breaks the symmetry with the action layer. RPCs keep tenant scoping a
-*mandatory function parameter* (`p_workspace_id`), reviewable in one file.
-psycopg2-direct is reserved for migrations and Phase-0-style verification
-scripts only.
+**1. (NEW — load-bearing) Provenance is the correctness mechanism;
+"verifiable" is the definition of done for the FIRST runnable query, not
+a later PR.** PR #13 made provenance a structural contract (TemplateSpec
+refuses templates without a `provenance` column; runner fails loud) —
+retained. But it deferred *resolution* and the *CI invariant test* to
+later PRs, creating a window in which a query returns rows whose
+provenance resolves to nothing 62% of the time. Present + CI-enforced +
+resolvable collapse into one DoD in PR A. *Rejected:* the prior plan's
+"ship #13, harden over PRs 8/11" — creates exactly the multi-PR unsafe
+window. *Also rejected:* resolve provenance lazily in the frontend —
+moves the correctness mechanism out of the tested backend contract into
+an untested rendering path.
 
-**2. Query shapes are a closed, hand-written registry — not a generic
-query algebra.** The roadmap explicitly says "start with the 5–10 query
-shapes that matter." We ship a `QueryTemplate` registry where each template
-is (a) a named, versioned, parameterised query with a typed parameter
-schema, (b) backed by exactly one reviewed PL/pgSQL function, (c)
-tenant-scoped by construction. New shapes are new registry entries + one
-function, mirroring how the action registry grew. *Rejected alternative:* a
-fluent `Patient.where(...).has_diagnosis(...)` builder that compiles
-arbitrary chains to SQL. That is the roadmap's *illustrative texture*, not
-a delivery contract — building a safe general compiler (join planning,
-index selection, injection-proof predicate composition, EXPLAIN regression
-guards) is a multi-month research project and an unbounded attack surface.
-We deliver the *ergonomics* of that example for the fixed template set; the
-fluent API, if ever wanted, becomes sugar over the registry later.
+**2. (Retained) The query layer is a compiler to PL/pgSQL RPCs, not an
+ORM over PostgREST.** Joins/EXISTS/pgvector/tenant-scope-as-mandatory-
+parameter are unattainable through the builder and invisible to the PR 5
+tenant guard if done via raw psycopg2 in handlers. *Rejected:*
+psycopg2-direct in handlers. Confirmed in #13's Phase-0.
 
-**3. Provenance is a column in the result row contract, enforced by a
-result-shape test — not threaded by convention.** Every template's
-PL/pgSQL function MUST return a `provenance` JSONB column per row:
-`{source_document_id, source_kind, occurred_on, page, snippet}`. A unit
-test introspects every registered template's declared output columns and
-fails CI if `provenance` is absent. This makes "every answer has a source"
-a structural property (the Phase 2 discipline: no fake properties), not a
-UI afterthought that silently rots. *Rejected alternative:* a post-query
-Python enrichment pass that re-queries `digitised_documents` to attach
-sources. It works but is N+1, drifts from the query's actual join, and can
-attribute the wrong document when a fact has multiple sources — the
-provenance must come from the same join that produced the fact.
+**3. (Retained) Query shapes are a closed, versioned registry — not a
+generic algebra.** *Rejected:* a fluent arbitrary-chain compiler
+(multi-month research project, unbounded injection surface).
 
-**4. The NL layer is a constrained intent classifier over the closed
-template set, and PII never leaves the box without an explicit user
-decision.** The clinician's free-text question goes to an LLM whose *only*
-job is to output `{template_id, params}` constrained to the registered
-template IDs and their typed param schemas (function/tool-calling with an
-enum of template IDs, not free-form SQL). The question text may contain PII
-(patient names). Whether that text — and which provider — is allowed is a
-**user decision** (locked: build disabled, decide later). The classifier
-returns "I can't answer that yet" with the answerable list for
-unmatched/low-confidence questions, never a guessed query. *Rejected
-outright:* NL2SQL (LLM emits SQL) — unbounded injection/exfiltration
-surface, ungovernable tenant scoping, the "research project" the roadmap
-warns against.
+**4. (Retained) The NL layer is the thinnest possible constrained intent
+classifier over the closed template enum, ships disabled, PII-gated.**
+*Rejected outright:* NL2SQL.
 
-**5. Standing queries reuse the existing scheduler the platform already
-runs.** The platform already runs background workers
-(`document_watcher.py`, `digitisation_export_worker.py`) as long-lived
-processes. A standing query is a registered
-`(template_id, params, schedule, workspace_id)` row whose execution writes
-rows into a new `briefing_items` table via the *same* RPC path. Phase 3
-ships the table, the materialiser, a manual trigger endpoint, and a single
-scheduler tick inside the existing worker — **not** pg_cron (not enabled;
-project-level change; would run as superuser outside tenant discipline),
-**not** Supabase Edge, **not** a new daemon. The thin briefing UI is
-**deferred to Phase 4** per the roadmap's own framing.
+**5. (Retained) Standing queries reuse the existing long-lived worker;
+one scheduler tick, not pg_cron, not a new daemon.**
 
-**6. The query layer is read-only and does NOT route through the
-ActionExecutor.** Queries are not mutations; they get no `action_audit_log`
-row. POPIA query-access-logging is a real future requirement but
-conflating it with the mutation audit log would pollute
-`affected_objects` semantics. Deferred to Phase 5; the single
-`run_template()` chokepoint is built so a logging decorator slots in later
-without a refactor.
+**6. (Retained) The query layer is read-only; does NOT route through
+ActionExecutor.** The `run_template()` chokepoint is where a future POPIA
+access-log decorator slots in (Phase-5 deferral, chokepoint exists).
+
+**7. (NEW — honesty about non-defendable cases) Where a safety case is
+not present on the corpus, ship the structural defence and label it
+"schema-correct, not corpus-exercised" — do not claim a tested defence
+that cannot be demonstrated.** Applies to reversed-source and two-source
+(findings #3, #4). *Rejected:* synthesising adversarial fixtures and
+presenting them as evidence the case is handled — that is itself a fake
+property, the exact Phase-2 anti-pattern.
+
+---
+
+## Disposition of the open PR #13
+
+**Recommendation: extend the #13 branch to meet the PR A bar before
+merge. Do NOT merge #13 as-is.**
+
+*Already satisfies PR A:* the structural provenance contract
+(`spec.py`/`runner.py`/`result.py`), the single tenant-scoped chokepoint,
+migration 024's provenance-in-join + mandatory `NOTIFY pgrst` pattern.
+
+*Missing for PR A (the unsafe gap):* (i) no **resolution** — a
+`source_document_id` is an opaque UUID; 62% resolve to nothing on real
+data; (ii) no **CI invariant test** that fails the build if a future
+template's SQL forgets provenance or returns an unresolvable id; (iii) no
+**HTTP surface** — a demo doctor cannot click a source; a Python REPL is
+insufficient for the present binding constraint.
+
+*Why extend, not merge-then-fix:* "merge as labelled-not-demo-safe" is a
+social control over a technical hazard — the runner works, someone wires
+an endpoint, the unsafe demo happens. The only guarantee the unsafe
+window never exists is to never land a mergeable artifact that answers a
+query without resolution. #13 is sound and ~1,330 LoC; extending
+on-branch is bounded. #13 becomes PR A.
 
 ---
 
 ## PR breakdown
 
-Total: **6 PRs (PR 6–11)**. Each independently mergeable. LoC estimates
-inflated ~40–50% over first instinct because the PR 3 estimate was 40%
-low — the dominant cost is PL/pgSQL + verification, not Python.
+Four PRs (A–D), close-out folded into PR D (the CI invariant moves *into*
+PR A as the gate, so a separate PR-11 ratifying invariants that have been
+load-bearing for three PRs is redundant). Deviation from the prior 6-PR
+shape is deliberate and justified per-boundary. Every boundary preserves
+the invariant: **no PR ships a query result a clinician could act on
+without verification present, CI-enforced, and resolvable.** LoC
+estimates corrected upward (PR 3's estimate ran 40% low; cost is
+PL/pgSQL + resolution + ugly-case verification, not Python).
 
-### PR 6 — Query IR + registry + ONE compiled template, end-to-end ✅
+### PR A — Structured query primitives WITH verifiable provenance (extends #13)
 
-**Load-bearing property:** a structured query expressed in ontology terms
-compiles to a tenant-scoped PL/pgSQL function, executes against real dev
-data, every result row carries provenance — proven on one shape before the
-pattern is replicated.
+**Load-bearing property:** the first runnable query returns rows whose
+provenance is present (contract), CI-enforced (build fails otherwise),
+and resolvable (every `source_document_id` either opens a real scan with
+a human citation, or is *explicitly and visibly* marked unresolvable —
+never a silent dead link), reachable over HTTP so a demo verifies by
+clicking.
 
-**Deliverables:** `ontology/query/{spec,registry,runner,result}.py`;
-`ontology/query/templates/patients_with_diagnosis_prefix.py`; migration
-`024_query_layer_diagnosis_template.sql`; `tests/test_query_layer_unit.py`;
-`scripts/verify_query_phase0.py`.
+**Deliverables (paths + honest LoC):**
+- *Retained from #13, unchanged:* `backend/ontology/query/{spec,registry,
+  runner,result,__init__,registered}.py`, `templates/
+  patients_with_diagnosis_prefix.py`, `migrations/024_…sql` (~0 new).
+- **`backend/ontology/query/provenance.py`** (~340) —
+  `resolve_provenance(supabase, rows, *, workspace_id)`: one
+  workspace-scoped batch query → `ResolvedSource{document_id, openable,
+  signed_url_or_none, citation, unresolvable_reason}`. Reuses the
+  signed-URL pattern at `digitisation.py:268` and the metadata shape of
+  `_audit_row_to_drawer_row`. Honest citation (`filename` +
+  `upload_date` + page; **no fabricated "referral letter"** — `doc_type`
+  0% populated). **The unresolvable path is first-class:** missing doc →
+  `openable=False`, explicit reason, explicit citation. This is the
+  safe/unsafe difference.
+- **`backend/app/api/query.py`** (~190) — `POST /api/query/run`;
+  `workspace_id` from `get_current_user` only (never body); new
+  `clinical_query` capability gate; rate limiter reusing the digitisation
+  pattern; response calls `resolve_provenance` so every row ships
+  resolved-or-explicitly-not. **The response envelope carries a
+  cohort-level `unresolvable_count`** (born here in PR A — the
+  cohort-altitude argument that mandated the reversed-source aggregate in
+  locked decision #2 applies *identically and more urgently* to the
+  dominant 62% dead-link case: a 40-row cohort where 25 sources are dead
+  is exactly the demo failure, and a per-row marker nobody scans does not
+  surface it). PR B adds `superseded_count` to the same envelope; the
+  shape is designed for that extension from PR A.
+- **`backend/migrations/025_query_capability_seed.sql`** (~40) — seed
+  `clinical_query`; `NOTIFY pgrst` discipline note.
+- **`backend/tests/test_query_layer_invariants.py`** (~280) — **the CI
+  gate, pulled forward from the prior PR 11.** Every template declares
+  `provenance`; every RPC takes `p_workspace_id` first; no template
+  bypasses `run_template`; `resolve_provenance` never returns
+  `openable=True` with no signed URL (silent-dead-link guard as an
+  executable invariant). **PLUS the row/aggregate-consistency invariant
+  (review-suggested, adopted as required-in-A): no result envelope can be
+  returned where `unresolvable_count` disagrees with the number of rows
+  whose resolved source is `openable=False` — the cohort-level and
+  row-level safety signals can never drift apart, because the aggregate
+  is precisely the signal that gets read.** The invariant is written
+  extensibly in PR A so PR B's `superseded_count` slots into the same
+  consistency check without a rewrite.
+- **`backend/tests/test_query_api.py`** (~180) — forged-body workspace
+  cannot cross tenants; every row resolved; unresolvable rows carry the
+  explicit marker, not null.
+- **`backend/scripts/verify_query_phase0.py`** (+~90) — extend with the
+  resolution probe: assert the known-15 orphaned-source rows return
+  `openable=False` + explicit reason (proves the unsafe case is *visibly*
+  handled, not blank/crashed).
 
-**Verification (the Phase-0 gate):** confirm a `STABLE` function returning
-`TABLE(... jsonb)` round-trips via `.rpc()` as typed dict rows; confirm
-`diagnoses.patient_id` ⋈ `patients.id` TEXT=TEXT no cast; `EXPLAIN` index
-usage. If (i) fails, retreat to psycopg2-direct + extend the PR 5 tenant
-guard.
+**Empirical verification (Phase-0) — DONE, with one corrected premise.**
+The 15/24 orphaned-source finding is re-asserted live by
+`verify_query_phase0.py` probe (iv): against the real DB, through the
+real RPC + real resolver + real signed-URL minting, the orphaned source
+resolves VISIBLY UNRESOLVABLE (citation `source document no longer
+available (id …e15a71)`) and a present source resolves OPENABLE with a
+signed URL (`Patient file.pdf, 7 May 2026`). The HTTP/auth stack
+(capability gate, forged-body inertness, error mapping) is verified by
+`test_query_api.py`. **Corrected premise:** the single browser
+click-through "one link opens, one visibly doesn't on one screen against
+a real entitled workspace" is NOT achievable on the current corpus.
+`demo-gp-workspace-001` (the only workspace `clinical_query` legitimately
+reaches, via `legacy_full_access_grant`) has 31 patients but **0
+diagnoses** — the shipped template returns empty there. The orphaned data
+lives in `test-workspace-*` (not entitled) and the resolvable case in
+`typec-workspace-001` (module_digitisation — correctly NOT entitled,
+ratchet-guarded). No single workspace is both entitled and data-bearing.
+Closing this needs a properly provisioned platform-tier demo workspace
+seeded with both a resolvable and an orphaned sourced diagnosis — NAMED
+here, not faked, and explicitly NOT closed by bending the entitlement
+mapping to a data-bearing workspace (that is the anti-pattern the
+entitlement decision rejected).
 
-**OUTCOME (actual):** Phase-0 CONFIRMED. Also surfaced the operational
-finding that every query migration must end with
-`NOTIFY pgrst, 'reload schema'` or the RPC 404s (PGRST202) until cache
-reload. Baked into migration 024; standing requirement for PR 7+.
+**Smoke-vehicle decision: RESOLVED — Option 1 (carry the browser
+contrast to PR B).** Rationale (from review): the browser click verifies
+*rendering*, a strictly weaker and different thing than the resolver
+*correctness contract* the probe already proves on live data; making it
+PR A's gate would contradict design choice #1 (correctness mechanism
+stays in the tested backend, not the rendering path). Provisioning a
+seeded workspace *now* (the rejected Option 2) is design choice #7's
+anti-pattern in a provisioning-script costume — proving a safety property
+against data manufactured to satisfy it. Option 1 is the only path that
+keeps the discipline: PR B independently *requires* a seeded, entitled,
+data-bearing demo workspace to verify its own briefing-set property, so
+the browser contrast rides on data that exists for PR B's own legitimate
+reasons, not a fixture built to pass a PR A click.
 
-**~1,330 LoC.**
+**PR A verification statement (REQUIRED WORDING — quote verbatim in the
+PR description; do not soften to "safety property verified"):** *The PR A
+safety property — every query row's provenance resolves to an openable
+scan with an honest citation, or is visibly marked unresolvable, never a
+silent dead link — is verified by an automated Phase-0 resolution probe
+on live data plus 46/46 invariant/API tests, including the known-orphaned
+rows returning `openable=False` with an explicit reason. The visual
+rendering of that distinction in a browser is deferred to PR B because no
+current workspace is both entitled to `clinical_query` and data-bearing,
+and manufacturing one solely to demonstrate it would be the
+construct-validity anti-pattern this plan rejects. What is proven:
+resolver correctness on real data. The edge not covered by PR A: the
+human-visible rendering of it.*
 
-### PR 7 — The morning-briefing / pre-consult query template set
+**Defers:** the briefing set, the ugly cases, NL, standing. Ships exactly
+one template — but fully safe.
 
-**Load-bearing property:** the 5–8 query shapes the briefing and
-pre-consult brief are composed from all exist, tenant-scoped,
-provenance-bearing, index-backed against real data.
+**~1,120 new on top of #13's ~1,330.**
 
-**Proposed set (locked — evidence-based):**
-1. `patients_with_diagnosis_prefix` (PR 6, extend with `order_by last_consultation`)
-2. `patients_not_seen_since(months)` — recall, uses `encounters.encounter_date` + `idx_encounters_date`
-3. `patient_active_medications(patient_id)` — pre-consult med list from `prescriptions`+`prescription_items`
-4. `patient_recent_consultations(patient_id, within_days)` — pre-consult timeline
-5. `patients_with_abnormal_recent_vitals(...)` — e.g. `bp_systolic > threshold` (vitals thin: 5 rows — ship schema-correct, document thinness)
-6. `patient_open_documents(patient_id)` — un-promoted/awaiting-validation docs
-7. lab-threshold shape — **built schema-correct, marked data-thin** (1 row, no LOINC; ready when lab ingestion exists, not faked)
+### PR B — Harden + broaden + the ugly cases
 
-**Deliverables:** 6 template modules; migration
-`025_query_layer_briefing_templates.sql`; extend unit tests +
-`test_query_templates_integration.py` (RUN_INTEGRATION gated).
+**Load-bearing property:** the briefing/pre-consult set exists,
+tenant-scoped, index-backed, provenance-verifiable; the three ugly cases
+are either defended-and-tested OR explicitly labelled
+schema-correct-not-corpus-exercised — never silently authoritative.
 
-**Verification:** each template against live dev DB; assert zero
-cross-workspace leakage (run as A, assert no B rows); every row has
-provenance OR explicit `source_kind="live_entry"`; `EXPLAIN` index usage on
-the two cohort queries; lab template asserted "0 rows, plan valid" with
-documented thinness.
+**CARRIED FROM PR A — un-skippable definition-of-done item (equal weight
+to the briefing-set verification, not prose in a description nobody
+re-reads):** the live browser openable-vs-unresolvable contrast deferred
+from PR A. PR B does not merge until a human eye has seen, in a browser
+through the real `:3001→:8002→:5001` chain, a query result rendering
+both an openable source (opens the real scan) and a visibly unresolvable
+one (explicit citation, no silent dead link). This is the FIRST time the
+resolved/unresolved distinction is visually confirmed; the plan's whole
+thesis is that the distinction must be *visible*, not merely *correct*,
+so this is load-bearing, not polish. **Constraint (rider 3, written now
+while it can be seen — in PR B the pressure to violate it will be live
+and this reasoning three weeks cold):** PR B's seeded demo workspace is
+provisioned for the *briefing templates' own verification needs first*;
+the browser-contrast check rides on whatever orphan/resolvable
+distribution that legitimate seed *naturally* produces. It must NOT be
+seeded-to-order to manufacture a resolvable+orphaned pair for the
+click-through (that re-imports Option 2's construct-validity
+anti-pattern through PR B's back door). If the honest briefing seed
+contains no orphan, the correct response is to record that the
+orphan-rendering case remains probe-verified-only and say so — never to
+inject an orphan to complete the demo.
 
-**~1,430 LoC.**
+**Deliverables:**
+- Template modules (~110 each): `patients_with_diagnosis_prefix`
+  (+`order_by last_consultation`), `patients_not_seen_since`,
+  `patient_active_medications`, `patient_recent_consultations`,
+  `patients_with_abnormal_recent_vitals` (`data_maturity="thin"`),
+  `patient_open_documents`, `patients_with_lab_threshold`
+  (`data_maturity="schema_only"`).
+- **`backend/migrations/026_query_layer_briefing_templates.sql`** (~620
+  PL/pgSQL — six functions, provenance-in-join, `p_workspace_id`-first,
+  trailing `NOTIFY pgrst`).
+- **Ugly-case handling (the part the prior plan underweighted):**
+  - **(i) Low-confidence:** provenance gains an optional `quality`
+    sub-object resolved from `gp_validation_sessions` (batch, same
+    workspace-scoped query, joined on `document_id`):
+    `{section_confidence_recoverable: bool}` — **no numeric score is
+    surfaced and no threshold exists** (locked decision #1). Recoverable
+    → citation suffix `extraction quality not individually verified
+    (document-level check available)`; not recoverable (the dominant
+    15/16 case) → `extraction quality not verified`. Never
+    "low-confidence," never a percentage, never a binary implying "known"
+    vouched for the fact. Implements locked decision #1 exactly.
+  - **(ii) Reversed/superseded source:** resolver checks
+    `action_audit_log` for `PromoteDocumentToPatientRecord` with
+    `reversed_by_audit_id IS NOT NULL` and no later non-reversed
+    promotion → per-row `quality.superseded=true` + citation suffix
+    `(source promotion was reversed — fact may be stale)`, **AND a
+    mandatory `superseded_count` in the result envelope** (locked
+    decision #2 — the cohort-altitude count is not optional). **Labelled
+    construct-validity-only** for the live-data demonstration (corpus
+    produces 0 — design choice #7); the per-row + aggregate plumbing is
+    still built and unit-tested.
+  - **(iii) Two-document fact:** resolver returns `sources: []` array,
+    citation lists both. Schema-correct, labelled not-corpus-exercised.
+- **`backend/tests/test_query_templates_integration.py`** (~360,
+  RUN_INTEGRATION-gated) — each template vs live dev DB; zero
+  cross-workspace leakage (run as `demo-gp-workspace-001`, assert no
+  `typec-workspace-001` rows); `EXPLAIN` index usage; lab/vitals asserted
+  thin; the three ugly branches (low-conf suffix; synthetic reversed
+  fixture → superseded marker; multi-source fixture → array form).
 
-### PR 8 — Provenance hardening + the query API endpoint
+**Empirical verification (all safety-load-bearing, all confirmed by the
+planning probe and to be re-asserted as tests):** confidence is
+section-level, recoverable 1/16; 0 live reversed-source facts; 0
+two-source patients; the 15/24 orphaned rows still render
+explicitly-unresolvable through the new templates (regression guard on
+PR A's core property).
 
-**Load-bearing property:** the query layer is reachable over HTTP,
-tenant-scoped from the auth context (never a client-supplied workspace),
-provenance deep-links to the actual source scan.
+**Defers:** NL (PR C); standing (PR D); lab non-thinness (needs lab
+ingestion, out of Phase 3).
 
-**Deliverables:** `app/api/query.py` (`POST /api/query/run` —
-`workspace_id` from `get_current_user` only, never body; new
-`clinical_query` capability gate; rate limiter reusing the digitisation
-pattern); migration `026_query_capability_seed.sql`;
-`ontology/query/provenance.py` (batch-resolve `source_document_id` →
-citation string + deep-link, one workspace-scoped query);
-`tests/test_query_api.py`.
+**Size (review-required, deliberately not a single number):** the
+ugly-case semantics that determine PR B's size are now locked (see
+"Decisions locked at review"), so PR B is no longer *unbounded* — but the
+LoC-projection method that produced the other estimates missed PR 3 by
+40% on strictly easier work, and PR B is the hardest PR (it carries all
+three ugly cases plus the briefing set). A single "~1,580" here would be
+false precision of exactly the kind this plan otherwise refuses. **PR B
+is sized by the locked semantics below, measured at implementation, not
+projected** — its boundary is the decided behaviour, not a number, and it
+is brought back complete (same bar as PR A), not estimated forward.
 
-**Verification:** TestClient proves a forged body `workspace_id` cannot
-read another workspace; live smoke through the proxy chain
-(`:3001 → :8002 → :5001`) confirms one provenance deep-link opens the
-right scan.
+### PR C — Thinnest NL mapping (ships DISABLED)
 
-**~1,100 LoC.**
+**Load-bearing property:** a small fixed phrasing set maps to a
+registered template + typed params via a constrained classifier over the
+closed enum; hard refusal outside the set; no PII-bearing text reaches an
+LLM unless the user explicitly authorises a provider (default off — merge
+cannot leak PII); rides on primitives already provenance-verifiable from
+A/B (brakes built and proven before the steering wheel).
 
-### PR 9 — The narrow NL layer (ships DISABLED)
+**Deliverables:**
+- **`backend/app/services/nl_query.py`** (~360) — constrained tool-call;
+  tool schema generated from the registry (`all_templates()`) so it
+  cannot drift; `NL_QUERY_LLM_ENABLED` default off; unmatched/low-conf →
+  refusal + answerable list, never a guess.
+- **`backend/app/api/query.py`** — `POST /api/query/ask` (~70).
+- **`backend/tests/test_nl_query.py`** (~260) — fixed phrasing golden set
+  vs **mocked** LLM (wiring, not intelligence); refusal path;
+  disabled-default proven (no LLM client constructed with flag unset).
+- **`backend/scripts/nl_query_eval.py`** (~120) — opt-in real-LLM eval,
+  never CI; accuracy reported in PR prose, never a gate.
 
-**Load-bearing property:** ~20 hand-mapped clinician question patterns
-classify to a registered template + typed params with a hard refusal for
-anything outside the set, and no PII-bearing query text reaches an LLM
-unless the user has explicitly authorised the provider.
+**Defers:** enabling the LLM (governance decision, user-deferred);
+provider choice; standing (PR D).
 
-**Deliverables:** `app/services/nl_query.py` (constrained tool-call mode;
-the tool schema is *generated from the PR 6 registry* so it can't drift;
-`NL_QUERY_LLM_ENABLED` defaults **off** so merging cannot leak PII);
-`POST /api/query/ask`; `tests/test_nl_query.py` (20-question golden set vs
-a **mocked** LLM — deterministic, no network in CI; refusal path; PII-gate
-default-off); `scripts/nl_query_eval.py` (opt-in real-LLM eval, never CI).
+**~810** (lower than the prior PR 9's ~1,180 — re-scoped to *thinnest
+viable*, mitigating the balloon by smaller scope not hope).
 
-**Verification:** golden set ≥18/20 against the mocked classifier
-(verifies wiring not LLM intelligence); real accuracy reported in the PR
-description as an honest measured number, NOT a CI gate.
-
-**~1,180 LoC.**
-
-### PR 10 — `briefing_items` + materialiser (standing queries), no UI
+### PR D — Standing-query materialisation (no UI) + Phase 3 close-out
 
 **Load-bearing property:** a registered standing query runs on a schedule
-inside the existing worker process and writes provenance-bearing rows into
-`briefing_items`, idempotently, tenant-scoped.
+in the existing worker and writes provenance-verifiable rows (A/B
+resolution applies — briefing rows carry openable citations or explicit
+unresolvable markers) into `briefing_items`, idempotently, tenant-scoped,
+RLS-deny-all.
 
-**Deliverables:** migration `027_briefing_items.sql` (RLS-enabled deny-all
-to anon, matching migration 018 discipline; add `briefing_items` to the PR
-5 tenant guard's table set — the ratchet only goes down);
-`ontology/query/standing.py` (StandingQuery registry +
-`materialise_standing_queries()` — wipe-and-reinsert per
-`(workspace_id, kind, as_of_date)`); worker scheduler tick;
-`POST /api/query/briefing/refresh` (manual) + `GET /api/query/briefing`;
-`tests/test_standing_queries.py`.
+**Deliverables:**
+- **`backend/migrations/027_briefing_items.sql`** (~110) — table;
+  RLS-deny-all per migration 018; **add `briefing_items` to the PR 5
+  tenant-guard table set (ratchet only goes down)**; `NOTIFY pgrst` note.
+- **`backend/ontology/query/standing.py`** (~330) — `StandingQuery`
+  registry + `materialise_standing_queries()` (wipe-and-reinsert per
+  `(workspace_id, kind, as_of_date)` → idempotent); each row through
+  `run_template` + `resolve_provenance` so briefing inherits the safety
+  property.
+- Worker scheduler tick (~90; runtime-topology assumption verified
+  empirically here; pg_cron the rejected-by-default fallback).
+- **`backend/app/api/query.py`** — `POST /api/query/briefing/refresh`
+  (manual) + `GET /api/query/briefing` (~80).
+- **`backend/tests/test_standing_queries.py`** (~240) — double-run row
+  stability (idempotent); tenant scoping; provenance preserved AND
+  resolved (orphaned-source rows still carry the explicit marker through
+  the briefing path — safety invariant survives materialisation).
+- **`ONTOLOGY_QUERY_LAYER_POSTMORTEM.md`** — Phase 3 close-out; the 15/24
+  orphaned-source finding recorded as a permanent data-quality finding
+  for a future backfill; what's documented-thin; what's
+  construct-validity-only; **and, recorded as a permanent residual (not a
+  deferral that gets closed later within Phase 3): verifiable provenance
+  defends the dead-link failure but renders the wrong-extraction failure
+  only checkable-but-not-checked — extraction correctness is upstream of
+  the query layer; the post-mortem states this in the same words as the
+  Context section so a future-self quoting the close-out to a regulator
+  cannot infer a stronger property than was built.**
+- **MANDATORY one-sentence scope note (named, not built):** "Conversion
+  instrumentation — measuring which briefing/pre-consult items a
+  prospecting or live practice acts on — is a known future consumer of
+  exactly this standing-query materialisation substrate; when customers
+  arrive it must be a small configuration of this infrastructure (a new
+  `StandingQuery` kind writing to `briefing_items`), not a forgotten
+  requirement rediscovered late."
 
-**Verification:** run materialiser twice → stable row count (idempotent);
-tenant scoping; provenance preserved; confirm the scheduler tick actually
-fires inside the worker process (verify the runtime-topology assumption,
-pg_cron the documented-but-rejected fallback).
+**Defers:** briefing UI (Phase 4, confirmed); conversion instrumentation
+(named only); POPIA query-access-logging (Phase 5, chokepoint exists).
 
-**~1,090 LoC.**
+**~950.**
 
-### PR 11 — Hardening, docs, Phase 3 close-out
-
-**Load-bearing property:** the query layer's safety invariants are tested
-as invariants; deferrals are documented as deliberate.
-
-**Deliverables:** `tests/test_query_layer_invariants.py` (every template's
-RPC takes `p_workspace_id`; every template declares `provenance`; no
-template module bypasses `run_template()`);
-`scripts/query_explain_regression.py`;
-`ONTOLOGY_QUERY_LAYER_POSTMORTEM.md`.
-
-**~600 LoC.**
-
-**Total Phase 3: ~6,730 LoC across 6 PRs.** Largest under-estimate risk is
-PR 9 (NL layer) if scope creeps.
+**Total: ~1,330 (retained #13) + 1,120 (PR A) + PR B *not projected,
+sized by locked semantics* + 810 (PR C) + 950 (PR D), 4 PRs.** A single
+grand total is deliberately withheld: it would be dominated by the one
+PR whose number this plan declines to assert. Cost is moved forward into
+PR A/B where the safety work lives; PR B is delivered complete, not
+estimated.
 
 ## Risks
 
-- **supabase-py REST can't do the joins — PL/pgSQL forced.** The one
-  unproven assumption was PR 6's Phase-0 (i) — *now confirmed*. Retreat
-  (psycopg2-direct → blind tenant guard) not needed.
-- **The NL layer balloons into a research project (highest risk).**
-  Mitigations: closed template enum (no NL2SQL), constrained tool-calling,
-  schema generated from the registry, golden-set CI on a mocked LLM, real
-  accuracy reported not gated. PR 9 is a *hand-mapped-template classifier
-  MVP*, not arbitrary-question answering.
-- **PII exposure to the LLM.** PR 9 defaults LLM disabled; enabling is a
-  separate governance decision.
-- **Provenance threading touches every query path.** A template that
-  forgets it is a fake-property regression. Mitigated by PR 11's invariant
-  test + PR 6's result-shape contract; until PR 11, a sloppy PR 7/8
-  template could ship without it (option: pull PR 11's invariant test
-  earlier).
-- **Lab data effectively absent (1 row, no LOINC, no patient_id).** The
-  roadmap's flagship query is undeliverable on real data in Phase 3.
-  Shipped schema-correct + documented-thin, never faked. The risk is
-  *expectation*, not engineering.
-- **Vitals thin (5 rows).** Abnormal-vitals cohort query real but near-
-  empty on dev. Same honesty discipline.
-- **Standing-query scheduler** assumes the existing worker is a persistent
-  process that can host a tick. Verified empirically in PR 10; pg_cron the
+- **The verifiability gap is the present dominant failure mode (finding
+  #1), not hypothetical.** 62% of dev sourced-diagnoses resolve to a
+  missing doc row. If PR A's resolver renders these as anything other
+  than visibly-unresolvable, the demo shows a confident answer with a
+  dead link. The orphaned-source explicit-marker test is the single
+  highest-priority test in Phase 3 — CI invariant in A, regression guard
+  in B and D.
+- **Confidence is coarse and mostly unrecoverable (finding #2).**
+  Section-level, recoverable 1/16. The honest design is correct but weak;
+  a high section score does not vouch for a specific fact. The original
+  risk — a "low-confidence" suffix creating false reassurance on the
+  silent ones — is structurally eliminated by **locked decision #1**: no
+  numeric score, no threshold, no word implying the fact was scored, and
+  the dominant case renders the explicit `extraction quality not
+  verified`. Residual: even this conservative phrasing is a
+  section-level proxy; mitigation is design choice #7 plus the
+  postmortem recording it as a permanent limitation.
+- **Reversed-source / two-source defences are not corpus-exercisable
+  (#3, #4).** Risk: a reviewer believes they're tested against real data.
+  Mitigation: explicit construct-validity-only labelling in PR prose,
+  postmortem, test names.
+- **`doc_type` 0% populated.** Citation cannot say "Lancet referral
+  letter." Honest builder; documented; not faked.
+- **NL balloon.** Mitigated structurally by re-scoping PR C smaller.
+- **Worker-topology assumption (PR D)** — verified empirically; pg_cron
   rejected-by-default fallback.
-- **Heterogeneous TEXT identifiers** (postmortem scar). All
-  `patient_id`/`id` joins are TEXT=TEXT, no `::uuid` cast (migration-015
-  bug). Verified in PR 6.
+- **Heterogeneous TEXT identifiers (postmortem scar)** — all
+  `patient_id`/`id` joins TEXT=TEXT, no `::uuid` cast; confirmed in #13
+  Phase-0 and re-probed (0 cross-workspace mismatches).
 
-## Underspecified decisions (status)
+## Decisions locked at review
 
-1. **Exact briefing query shapes** — RESOLVED: plan's evidence-based set.
-2. **NL LLM provider / PII** — RESOLVED: build disabled, decide later.
-3. **Scheduler mechanism** — ride the plan (tick in existing worker);
-   verified in PR 10.
-4. **Briefing UI in Phase 3?** — RESOLVED: no, deferred to Phase 4.
-5. **Query access-logging (POPIA)** — Phase 5 deferral; chokepoint built
-   in PR 6.
-6. **`clinical_query` capability** — seeded NOT-in-foundation per the PR 3
-   `patient_admin` precedent; confirm at PR 8.
+All four decisions the plan reserved are now resolved at plan review.
+They are LOCKED — coding implements exactly these; a deviation requires a
+new explicit user call, not an implementer's judgement. The reasoning is
+recorded so the calls can be overridden deliberately rather than
+re-derived.
+
+(Also locked at planning time, not re-asked: query-shape set,
+NL-disabled, briefing-UI → Phase 4.)
+
+**1. "Low-confidence" per-fact → binary, conservative phrasing, NO
+implied per-fact score, NO threshold.** (safety-load-bearing) The
+stronger form of option (b). Reasoning: a section-level signal rendered
+as a per-fact suffix manufactures a confidence claim the data does not
+support — structurally the exact failure this plan exists to prevent. A
+clinician seeing "(low-confidence)" on fact X but not Y will infer Y is
+*more* confident; but the signal is recoverable for 1/16 documents, so
+for almost all facts the *absence* of the suffix means "we have no idea,"
+not "this is fine" — turning absence-of-signal into implied reassurance.
+There is therefore **no threshold** (the option-(a) "which threshold"
+question is void — there is no number to threshold against at the fact
+level) and **no word that implies the fact itself was scored.** Locked
+citation wording:
+   - section confidence *recoverable* for the source document →
+     `extraction quality not individually verified (document-level check
+     available)`
+   - section confidence *not recoverable* (the dominant 15/16 case) →
+     `extraction quality not verified`
+   Never "low-confidence," never a percentage, never a known/unknown
+   binary that implies "known" vouched for the fact.
+
+**2. Reversed/superseded source → per-row suffix PLUS a mandatory
+aggregate count in the result envelope.** (safety-load-bearing) Option
+(b) for the single-fact case AND a non-optional cohort-level count.
+Reasoning: the per-row suffix `(source promotion was reversed — fact may
+be stale)` is correct for one fact a clinician reads, but the failure
+that hurts is a *cohort* query where 3 of 40 rows rest on reversed
+sources and the clinician scans the list and acts on the cohort whole —
+the per-row marker is invisible at the altitude the query is actually
+used. The result envelope therefore carries `superseded_count` (e.g. "3
+of 40 results have a superseded source") surfaced at cohort level.
+Hiding (a) is rejected — silent cohort shrinkage is its own trust
+violation. Flag-only (c) is rejected — same per-row-attention failure as
+the suffix alone. **The aggregate count is not optional polish; it is the
+part that makes the defence work at the altitude the failure occurs.**
+(Corpus produces 0 — construct-validity-only per design choice #7; the
+*aggregate plumbing* is still built and unit-tested, only the live-data
+demonstration is labelled not-corpus-exercised.)
+
+**3. Unresolvable-case citation → truncated id, not opaque.** Locked:
+`source document no longer available (id …e15a71)` (last 6 hex of the
+id). Reasoning: a partial id reads as "the system knows precisely which
+record and is telling me it's gone" — the honest state, a precise
+known-unknown — whereas bare "source unavailable" reads as a vague system
+fault. The truncated id converts a scary blank into the safe-failure
+posture the whole plan is built around.
+
+**4. `clinical_query` stays explicit-grant, OUT of foundation; product
+set resolved at review on a COHERENCE argument.** Locked: explicit-grant,
+never `foundation_bundle`, never default — highest-blast-radius read
+surface. The product set within that lock, forced into the open by the
+entitlement reality, is resolved as: `platform_essential` +
+`platform_professional` (per the 023 `patient_admin` precedent) **+
+`legacy_full_access_grant`**. The justification is coherence, NOT
+demo-enablement: `legacy_full_access_grant` already entails
+`analytics_cohorts`, `audit_log`, and `clinical_ai_*` (strictly more
+sensitive read surfaces); a "full access" grant that excludes the query
+layer is an *incoherent* entitlement, not a tighter blast radius. That
+this also lets the flagship demo practice exercise the query layer is a
+*consequence* of the demo workspace being correctly on full-access — not
+the reason for the mapping. Precedent rule established: entitlement
+mappings are chosen for semantic correctness; workspaces are placed on
+the product that matches their role; a demo that needs a capability
+moves the workspace to the right product, never widens the capability to
+reach the workspace. **`module_digitisation` is excluded as a written
+customer promise** (the Type C leave-behind), regression-guarded by a
+build-failing CI ratchet
+(`test_query_layer_invariants.py::test_module_digitisation_never_entails_clinical_query`,
+proven non-vacuous against one-line / multi-line / reversed-order
+injection). Migration 025 seeds this; its header encodes the coherence
+justification and the corrected corpus-honesty finding (below) so a
+future maintainer cannot re-derive it wrongly.
+
+*Corpus-honesty finding attached to this decision:* the workspace this
+mapping legitimately reaches (`demo-gp-workspace-001`,
+`legacy_full_access_grant`) has 0 diagnoses, so the shipped template is
+empty there; the orphaned/resolvable data lives in non-entitled
+workspaces. The resolver safety property is verified by Phase-0 probe
+(iv) + the API tests; a one-screen browser click-through needs a
+provisioned platform-tier demo workspace (named, not faked). See the PR
+A "Empirical verification" block and the open smoke-vehicle decision.
 
 ## What Phase 3 earns when it lands
 
-When PR 11 merges, SurgiScan stops being a digitiser and becomes queryable
-clinical infrastructure: a clinician asks one of ~20 known questions in
-plain language and gets a ranked, tenant-scoped answer where *every single
-row carries the scanned document it came from* — "Mrs Khumalo, Type 2
-diabetes (recorded 8 Mar 2026, from Lancet referral letter, page 1)" with a
-one-click link to the actual scan. The morning briefing and pre-consult
-brief are no longer features to build — they are registered standing
-queries that already materialise on a schedule into `briefing_items`,
-waiting for the Phase 4 UI. The platform earns this *honestly*: the query
-layer is provenance-bearing by construction (a CI invariant), tenant-scoped
-by construction (the same discipline PR 5's guard enforces for writes), and
-the things it cannot yet do — lab-threshold questions on absent data,
-questions outside the 20 patterns, see PII without a governance decision —
-are documented deferrals, not silent gaps.
+When PR D merges, SurgiScan stops being a digitiser and becomes
+*trustworthy* queryable clinical infrastructure — the word that matters
+is *trustworthy*, not *queryable*. From the first runnable query in PR A,
+a clinician (or a prospecting doctor in a demo) gets a tenant-scoped
+ranked answer where every row's source is not just present but
+*verifiable*: it opens the actual scan with a human citation, or it tells
+the clinician *visibly* that the source cannot be opened. **The dead-link
+failure mode — the measured, dominant one — becomes a known unknown the
+clinician sees, never a confident wrong answer with a dead link they
+trust.** The residual that remains, stated without softening: a row whose
+link *does* open can still rest on a wrong extraction of the underlying
+scan; verifiable provenance makes that checkable by whoever opens the
+scan, but a demo viewer and a hurried clinician do not, so
+wrong-extraction-behind-a-live-link is checkable-but-not-checked — a real
+residual risk Phase 3 surfaces and does not close (extraction correctness
+is upstream of the query layer). The morning briefing and pre-consult
+brief are registered standing queries already materialising into
+`briefing_items`, inheriting that verifiability, waiting only for the
+Phase 4 UI. The platform earns this honestly: provenance is the
+correctness mechanism (a CI invariant from line one, not bolted on three
+PRs late), tenant-scoping is structural, and the things it cannot do —
+guarantee a live-link extraction is itself correct (only make it
+checkable), precise per-fact confidence, defend a reversed-source live
+fact, answer lab-threshold questions, see PII without a governance
+decision — are documented deferrals and labelled construct-validity
+limits, not silent gaps.

--- a/ONTOLOGY_PHASE3_QUERY_LAYER_PLAN.md
+++ b/ONTOLOGY_PHASE3_QUERY_LAYER_PLAN.md
@@ -1,0 +1,323 @@
+# Phase 3 — The Query Layer: PR-by-PR Implementation Plan
+
+> Status tracker (update as PRs land):
+> - **PR 6** — query foundation + first compiled template — ✅ merged-pending (#13)
+> - **PR 7** — briefing/pre-consult query set — ⬜ not started
+> - **PR 8** — HTTP query API — ⬜ not started
+> - **PR 9** — narrow NL layer (ships disabled) — ⬜ not started
+> - **PR 10** — briefing_items + materialiser — ⬜ not started
+> - **PR 11** — invariant hardening + postmortem — ⬜ not started
+>
+> User decisions locked at planning time:
+> - Query shapes: use the plan's evidence-based set (confirmed)
+> - NL layer: build disabled, decide provider later (confirmed)
+> - Briefing UI: deferred to Phase 4 (confirmed)
+> - Scheduler / access-logging / clinical_query capability: ride the plan's
+>   recommendation, verified in their respective PRs
+
+---
+
+## Context
+
+Phases 0–2 built the ontology spine (typed `Patient`/`Document`/`Consultation`
+objects, a link registry) and made every mutation a first-class audited
+`Action` flowing through `app/actions/executor.py` with a hard-won "thin
+Python orchestrator + PL/pgSQL RPC for the ACID/locking part" pattern.
+Phase 3 turns the spine load-bearing for *reads*: clinicians ask questions,
+get ranked answers, every answer carries its source document. The roadmap's
+four sub-goals (structured query primitives → narrow NL layer →
+provenance-in-every-answer → standing-query materialisation) are correctly
+sequenced but each is a different risk class. The empirical probe of the
+live DB changes the plan materially: clinical *write* tables are
+well-populated (67 patients, 79 encounters, 45 prescriptions, 24 diagnoses,
+`document_embeddings` already at 76 rows with an ivfflat index) but the lab
+corpus is effectively empty (1 `lab_results` row, `test_code` NULL, no
+LOINC), and `lab_results` has no `patient_id`/`workspace_id` (joins through
+`lab_orders`). The roadmap's flagship example query
+(`has_lab_result(loinc="4548-4", ...)`) is therefore aspirational against
+current data and must be planned as schema-correct-but-data-thin, not as
+the demo. supabase-py REST as `service_role` (RLS-bypassing) remains the
+only mutation/read path from Python; complex joins/aggregations/pgvector
+force PL/pgSQL RPCs or the psycopg2 `DATABASE_URL` path, exactly as in
+Phase 2.
+
+## Design choices
+
+**1. The query layer is a compiler to PL/pgSQL RPCs, not an ORM over
+PostgREST.** The roadmap's example query spans Patient → Diagnosis (FK
+join) → LabResult (two-hop join through `lab_orders`) → ordering on a
+denormalised summary. supabase-py's PostgREST builder cannot express
+multi-table joins with per-branch filters, `EXISTS` sub-selects, or
+`embedding <=> $1` ordering. The established and *only proven* pattern
+(migrations 011, 015, 021, 022) is: a Python builder produces a structured
+query IR, a small set of parameterised PL/pgSQL `STABLE` functions execute
+it, the supabase client calls them via `.rpc()`. *Rejected alternative:*
+the direct psycopg2 `DATABASE_URL` path for ad-hoc SQL. It works (used for
+migrations) and bypasses RLS, but it (a) duplicates the connection/secrets
+surface inside request handlers, (b) makes the PR 5 AST tenant-guard blind
+(the guard only understands `supabase.table(...)` chains — raw psycopg2 SQL
+is invisible to it, so a missing `workspace_id` would not trip CI), and (c)
+breaks the symmetry with the action layer. RPCs keep tenant scoping a
+*mandatory function parameter* (`p_workspace_id`), reviewable in one file.
+psycopg2-direct is reserved for migrations and Phase-0-style verification
+scripts only.
+
+**2. Query shapes are a closed, hand-written registry — not a generic
+query algebra.** The roadmap explicitly says "start with the 5–10 query
+shapes that matter." We ship a `QueryTemplate` registry where each template
+is (a) a named, versioned, parameterised query with a typed parameter
+schema, (b) backed by exactly one reviewed PL/pgSQL function, (c)
+tenant-scoped by construction. New shapes are new registry entries + one
+function, mirroring how the action registry grew. *Rejected alternative:* a
+fluent `Patient.where(...).has_diagnosis(...)` builder that compiles
+arbitrary chains to SQL. That is the roadmap's *illustrative texture*, not
+a delivery contract — building a safe general compiler (join planning,
+index selection, injection-proof predicate composition, EXPLAIN regression
+guards) is a multi-month research project and an unbounded attack surface.
+We deliver the *ergonomics* of that example for the fixed template set; the
+fluent API, if ever wanted, becomes sugar over the registry later.
+
+**3. Provenance is a column in the result row contract, enforced by a
+result-shape test — not threaded by convention.** Every template's
+PL/pgSQL function MUST return a `provenance` JSONB column per row:
+`{source_document_id, source_kind, occurred_on, page, snippet}`. A unit
+test introspects every registered template's declared output columns and
+fails CI if `provenance` is absent. This makes "every answer has a source"
+a structural property (the Phase 2 discipline: no fake properties), not a
+UI afterthought that silently rots. *Rejected alternative:* a post-query
+Python enrichment pass that re-queries `digitised_documents` to attach
+sources. It works but is N+1, drifts from the query's actual join, and can
+attribute the wrong document when a fact has multiple sources — the
+provenance must come from the same join that produced the fact.
+
+**4. The NL layer is a constrained intent classifier over the closed
+template set, and PII never leaves the box without an explicit user
+decision.** The clinician's free-text question goes to an LLM whose *only*
+job is to output `{template_id, params}` constrained to the registered
+template IDs and their typed param schemas (function/tool-calling with an
+enum of template IDs, not free-form SQL). The question text may contain PII
+(patient names). Whether that text — and which provider — is allowed is a
+**user decision** (locked: build disabled, decide later). The classifier
+returns "I can't answer that yet" with the answerable list for
+unmatched/low-confidence questions, never a guessed query. *Rejected
+outright:* NL2SQL (LLM emits SQL) — unbounded injection/exfiltration
+surface, ungovernable tenant scoping, the "research project" the roadmap
+warns against.
+
+**5. Standing queries reuse the existing scheduler the platform already
+runs.** The platform already runs background workers
+(`document_watcher.py`, `digitisation_export_worker.py`) as long-lived
+processes. A standing query is a registered
+`(template_id, params, schedule, workspace_id)` row whose execution writes
+rows into a new `briefing_items` table via the *same* RPC path. Phase 3
+ships the table, the materialiser, a manual trigger endpoint, and a single
+scheduler tick inside the existing worker — **not** pg_cron (not enabled;
+project-level change; would run as superuser outside tenant discipline),
+**not** Supabase Edge, **not** a new daemon. The thin briefing UI is
+**deferred to Phase 4** per the roadmap's own framing.
+
+**6. The query layer is read-only and does NOT route through the
+ActionExecutor.** Queries are not mutations; they get no `action_audit_log`
+row. POPIA query-access-logging is a real future requirement but
+conflating it with the mutation audit log would pollute
+`affected_objects` semantics. Deferred to Phase 5; the single
+`run_template()` chokepoint is built so a logging decorator slots in later
+without a refactor.
+
+---
+
+## PR breakdown
+
+Total: **6 PRs (PR 6–11)**. Each independently mergeable. LoC estimates
+inflated ~40–50% over first instinct because the PR 3 estimate was 40%
+low — the dominant cost is PL/pgSQL + verification, not Python.
+
+### PR 6 — Query IR + registry + ONE compiled template, end-to-end ✅
+
+**Load-bearing property:** a structured query expressed in ontology terms
+compiles to a tenant-scoped PL/pgSQL function, executes against real dev
+data, every result row carries provenance — proven on one shape before the
+pattern is replicated.
+
+**Deliverables:** `ontology/query/{spec,registry,runner,result}.py`;
+`ontology/query/templates/patients_with_diagnosis_prefix.py`; migration
+`024_query_layer_diagnosis_template.sql`; `tests/test_query_layer_unit.py`;
+`scripts/verify_query_phase0.py`.
+
+**Verification (the Phase-0 gate):** confirm a `STABLE` function returning
+`TABLE(... jsonb)` round-trips via `.rpc()` as typed dict rows; confirm
+`diagnoses.patient_id` ⋈ `patients.id` TEXT=TEXT no cast; `EXPLAIN` index
+usage. If (i) fails, retreat to psycopg2-direct + extend the PR 5 tenant
+guard.
+
+**OUTCOME (actual):** Phase-0 CONFIRMED. Also surfaced the operational
+finding that every query migration must end with
+`NOTIFY pgrst, 'reload schema'` or the RPC 404s (PGRST202) until cache
+reload. Baked into migration 024; standing requirement for PR 7+.
+
+**~1,330 LoC.**
+
+### PR 7 — The morning-briefing / pre-consult query template set
+
+**Load-bearing property:** the 5–8 query shapes the briefing and
+pre-consult brief are composed from all exist, tenant-scoped,
+provenance-bearing, index-backed against real data.
+
+**Proposed set (locked — evidence-based):**
+1. `patients_with_diagnosis_prefix` (PR 6, extend with `order_by last_consultation`)
+2. `patients_not_seen_since(months)` — recall, uses `encounters.encounter_date` + `idx_encounters_date`
+3. `patient_active_medications(patient_id)` — pre-consult med list from `prescriptions`+`prescription_items`
+4. `patient_recent_consultations(patient_id, within_days)` — pre-consult timeline
+5. `patients_with_abnormal_recent_vitals(...)` — e.g. `bp_systolic > threshold` (vitals thin: 5 rows — ship schema-correct, document thinness)
+6. `patient_open_documents(patient_id)` — un-promoted/awaiting-validation docs
+7. lab-threshold shape — **built schema-correct, marked data-thin** (1 row, no LOINC; ready when lab ingestion exists, not faked)
+
+**Deliverables:** 6 template modules; migration
+`025_query_layer_briefing_templates.sql`; extend unit tests +
+`test_query_templates_integration.py` (RUN_INTEGRATION gated).
+
+**Verification:** each template against live dev DB; assert zero
+cross-workspace leakage (run as A, assert no B rows); every row has
+provenance OR explicit `source_kind="live_entry"`; `EXPLAIN` index usage on
+the two cohort queries; lab template asserted "0 rows, plan valid" with
+documented thinness.
+
+**~1,430 LoC.**
+
+### PR 8 — Provenance hardening + the query API endpoint
+
+**Load-bearing property:** the query layer is reachable over HTTP,
+tenant-scoped from the auth context (never a client-supplied workspace),
+provenance deep-links to the actual source scan.
+
+**Deliverables:** `app/api/query.py` (`POST /api/query/run` —
+`workspace_id` from `get_current_user` only, never body; new
+`clinical_query` capability gate; rate limiter reusing the digitisation
+pattern); migration `026_query_capability_seed.sql`;
+`ontology/query/provenance.py` (batch-resolve `source_document_id` →
+citation string + deep-link, one workspace-scoped query);
+`tests/test_query_api.py`.
+
+**Verification:** TestClient proves a forged body `workspace_id` cannot
+read another workspace; live smoke through the proxy chain
+(`:3001 → :8002 → :5001`) confirms one provenance deep-link opens the
+right scan.
+
+**~1,100 LoC.**
+
+### PR 9 — The narrow NL layer (ships DISABLED)
+
+**Load-bearing property:** ~20 hand-mapped clinician question patterns
+classify to a registered template + typed params with a hard refusal for
+anything outside the set, and no PII-bearing query text reaches an LLM
+unless the user has explicitly authorised the provider.
+
+**Deliverables:** `app/services/nl_query.py` (constrained tool-call mode;
+the tool schema is *generated from the PR 6 registry* so it can't drift;
+`NL_QUERY_LLM_ENABLED` defaults **off** so merging cannot leak PII);
+`POST /api/query/ask`; `tests/test_nl_query.py` (20-question golden set vs
+a **mocked** LLM — deterministic, no network in CI; refusal path; PII-gate
+default-off); `scripts/nl_query_eval.py` (opt-in real-LLM eval, never CI).
+
+**Verification:** golden set ≥18/20 against the mocked classifier
+(verifies wiring not LLM intelligence); real accuracy reported in the PR
+description as an honest measured number, NOT a CI gate.
+
+**~1,180 LoC.**
+
+### PR 10 — `briefing_items` + materialiser (standing queries), no UI
+
+**Load-bearing property:** a registered standing query runs on a schedule
+inside the existing worker process and writes provenance-bearing rows into
+`briefing_items`, idempotently, tenant-scoped.
+
+**Deliverables:** migration `027_briefing_items.sql` (RLS-enabled deny-all
+to anon, matching migration 018 discipline; add `briefing_items` to the PR
+5 tenant guard's table set — the ratchet only goes down);
+`ontology/query/standing.py` (StandingQuery registry +
+`materialise_standing_queries()` — wipe-and-reinsert per
+`(workspace_id, kind, as_of_date)`); worker scheduler tick;
+`POST /api/query/briefing/refresh` (manual) + `GET /api/query/briefing`;
+`tests/test_standing_queries.py`.
+
+**Verification:** run materialiser twice → stable row count (idempotent);
+tenant scoping; provenance preserved; confirm the scheduler tick actually
+fires inside the worker process (verify the runtime-topology assumption,
+pg_cron the documented-but-rejected fallback).
+
+**~1,090 LoC.**
+
+### PR 11 — Hardening, docs, Phase 3 close-out
+
+**Load-bearing property:** the query layer's safety invariants are tested
+as invariants; deferrals are documented as deliberate.
+
+**Deliverables:** `tests/test_query_layer_invariants.py` (every template's
+RPC takes `p_workspace_id`; every template declares `provenance`; no
+template module bypasses `run_template()`);
+`scripts/query_explain_regression.py`;
+`ONTOLOGY_QUERY_LAYER_POSTMORTEM.md`.
+
+**~600 LoC.**
+
+**Total Phase 3: ~6,730 LoC across 6 PRs.** Largest under-estimate risk is
+PR 9 (NL layer) if scope creeps.
+
+## Risks
+
+- **supabase-py REST can't do the joins — PL/pgSQL forced.** The one
+  unproven assumption was PR 6's Phase-0 (i) — *now confirmed*. Retreat
+  (psycopg2-direct → blind tenant guard) not needed.
+- **The NL layer balloons into a research project (highest risk).**
+  Mitigations: closed template enum (no NL2SQL), constrained tool-calling,
+  schema generated from the registry, golden-set CI on a mocked LLM, real
+  accuracy reported not gated. PR 9 is a *hand-mapped-template classifier
+  MVP*, not arbitrary-question answering.
+- **PII exposure to the LLM.** PR 9 defaults LLM disabled; enabling is a
+  separate governance decision.
+- **Provenance threading touches every query path.** A template that
+  forgets it is a fake-property regression. Mitigated by PR 11's invariant
+  test + PR 6's result-shape contract; until PR 11, a sloppy PR 7/8
+  template could ship without it (option: pull PR 11's invariant test
+  earlier).
+- **Lab data effectively absent (1 row, no LOINC, no patient_id).** The
+  roadmap's flagship query is undeliverable on real data in Phase 3.
+  Shipped schema-correct + documented-thin, never faked. The risk is
+  *expectation*, not engineering.
+- **Vitals thin (5 rows).** Abnormal-vitals cohort query real but near-
+  empty on dev. Same honesty discipline.
+- **Standing-query scheduler** assumes the existing worker is a persistent
+  process that can host a tick. Verified empirically in PR 10; pg_cron the
+  rejected-by-default fallback.
+- **Heterogeneous TEXT identifiers** (postmortem scar). All
+  `patient_id`/`id` joins are TEXT=TEXT, no `::uuid` cast (migration-015
+  bug). Verified in PR 6.
+
+## Underspecified decisions (status)
+
+1. **Exact briefing query shapes** — RESOLVED: plan's evidence-based set.
+2. **NL LLM provider / PII** — RESOLVED: build disabled, decide later.
+3. **Scheduler mechanism** — ride the plan (tick in existing worker);
+   verified in PR 10.
+4. **Briefing UI in Phase 3?** — RESOLVED: no, deferred to Phase 4.
+5. **Query access-logging (POPIA)** — Phase 5 deferral; chokepoint built
+   in PR 6.
+6. **`clinical_query` capability** — seeded NOT-in-foundation per the PR 3
+   `patient_admin` precedent; confirm at PR 8.
+
+## What Phase 3 earns when it lands
+
+When PR 11 merges, SurgiScan stops being a digitiser and becomes queryable
+clinical infrastructure: a clinician asks one of ~20 known questions in
+plain language and gets a ranked, tenant-scoped answer where *every single
+row carries the scanned document it came from* — "Mrs Khumalo, Type 2
+diabetes (recorded 8 Mar 2026, from Lancet referral letter, page 1)" with a
+one-click link to the actual scan. The morning briefing and pre-consult
+brief are no longer features to build — they are registered standing
+queries that already materialise on a schedule into `briefing_items`,
+waiting for the Phase 4 UI. The platform earns this *honestly*: the query
+layer is provenance-bearing by construction (a CI invariant), tenant-scoped
+by construction (the same discipline PR 5's guard enforces for writes), and
+the things it cannot yet do — lab-threshold questions on absent data,
+questions outside the 20 patterns, see PII without a governance decision —
+are documented deferrals, not silent gaps.

--- a/backend/app/api/query.py
+++ b/backend/app/api/query.py
@@ -1,0 +1,199 @@
+"""
+query — the HTTP surface for the Phase-3 query layer (PR A).
+
+One endpoint that matters: `POST /api/query/run`. It is the reason PR #13
+could not merge as-is. The runner and the provenance contract are sound,
+but a query result a clinician can act on did not exist over HTTP — a
+Python REPL is not the binding constraint; a demo doctor clicking a
+source is. This endpoint makes the safe artifact reachable, and reachable
+*only* in its safe form: every row comes back with its provenance
+resolved to an openable scan or an explicitly, visibly unresolvable
+marker — never a silent dead link — and the envelope carries a
+cohort-level `unresolvable_count` so the dead-link signal is visible at
+the altitude a clinician actually reads a 40-row answer.
+
+Security shape, deliberately tight (it is the highest-blast-radius read
+surface in the system — it runs cross-cutting clinical queries):
+
+  * `workspace_id` is taken from the authenticated user ONLY, never from
+    the request body. A forged body workspace is structurally inert: the
+    request model has no such field and the runner is handed the auth
+    workspace. Tenant scope is not a check here, it is the absence of any
+    other path.
+  * Gated on the `clinical_query` capability — explicit-grant, NOT in the
+    foundation set (locked decision #4; same posture as PR 3's
+    `patient_admin`).
+  * Per-user rate limited (same in-process sliding-window pattern as
+    digitisation `/search`).
+
+Read-only by construction: this does NOT route through the
+ActionExecutor (queries are not actions; no audit row). `run_template`
+is the one chokepoint a future POPIA access-log decorator attaches to
+(Phase 5 — deferred, chokepoint already exists).
+"""
+
+from __future__ import annotations
+
+import os
+import time as _time
+from collections import deque as _deque
+from threading import Lock as _Lock
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.api.auth import require_capability
+from ontology.query import QueryError, resolve_provenance, run_template
+
+router = APIRouter(prefix="/api/query", tags=["Query Layer"])
+
+
+# Lazy supabase client — mirrors clinical_actions._sb(). Avoids
+# hard-failing at import time during test collection when env is unset.
+_supabase = None
+
+
+def _sb():
+    global _supabase
+    if _supabase is None:
+        from supabase import create_client
+
+        url = os.environ.get("SUPABASE_URL")
+        key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get(
+            "SUPABASE_KEY"
+        )
+        if not url or not key:
+            raise RuntimeError("SUPABASE_URL / SUPABASE_SERVICE_KEY missing")
+        _supabase = create_client(url, key)
+    return _supabase
+
+
+# ---------------------------------------------------------------------------
+# Per-user rate limiter — verbatim shape of digitisation._enforce_search_rate_limit.
+# Query execution is cheap but a runaway frontend or a scripted caller
+# should not be able to enumerate a practice's cohorts unbounded.
+# ---------------------------------------------------------------------------
+_rate_lock = _Lock()
+_rate_state: Dict[str, _deque] = {}
+_RATE_WINDOW_S = 60
+_RATE_MAX = 30
+
+
+def _enforce_rate_limit(user_email: str) -> None:
+    now = _time.monotonic()
+    with _rate_lock:
+        bucket = _rate_state.setdefault(user_email, _deque())
+        while bucket and now - bucket[0] > _RATE_WINDOW_S:
+            bucket.popleft()
+        if len(bucket) >= _RATE_MAX:
+            retry = int(_RATE_WINDOW_S - (now - bucket[0])) + 1
+            raise HTTPException(
+                status_code=429,
+                detail=f"Query rate limit: {_RATE_MAX}/min. Retry in {retry}s.",
+                headers={"Retry-After": str(retry)},
+            )
+        bucket.append(now)
+
+
+# QueryError.code → HTTP status. Kept explicit (not a catch-all) so the
+# vocabulary is auditable: a template bug is a 500, a caller mistake is a
+# 4xx, a cold PostgREST cache is a retryable 503.
+_CODE_TO_STATUS: Dict[str, int] = {
+    "unknown_template": status.HTTP_404_NOT_FOUND,
+    "missing_workspace": status.HTTP_400_BAD_REQUEST,
+    "unknown_param": status.HTTP_422_UNPROCESSABLE_CONTENT,
+    "invalid_param": status.HTTP_422_UNPROCESSABLE_CONTENT,
+    "provenance_missing": status.HTTP_500_INTERNAL_SERVER_ERROR,
+    "bad_rpc_shape": status.HTTP_500_INTERNAL_SERVER_ERROR,
+    "template_unavailable": status.HTTP_503_SERVICE_UNAVAILABLE,
+}
+_DEFAULT_ERROR_STATUS = status.HTTP_400_BAD_REQUEST
+
+
+class QueryRunRequest(BaseModel):
+    """Note the absence of `workspace_id`. It is intentional and
+    load-bearing: the only place a workspace can come from is the
+    authenticated user. A client that adds workspace_id to the body
+    achieves nothing — the field does not exist on this model and the
+    runner is never handed body data for scoping."""
+
+    template_id: str = Field(..., min_length=1)
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+@router.get("/templates")
+async def list_templates(
+    current_user: dict = Depends(require_capability("clinical_query")),
+):
+    """The closed set of query shapes this practice may run. Read-only;
+    no data, just the registry — lets a UI (and PR C's NL layer) discover
+    what is answerable instead of guessing."""
+    from ontology.query import all_templates
+
+    return {
+        "templates": [
+            {
+                "id": t.id,
+                "version": t.version,
+                "description": t.description,
+                "data_maturity": t.data_maturity,
+                "params": [
+                    {
+                        "name": p.name,
+                        "type": p.py_type.__name__,
+                        "required": p.required,
+                        "default": p.default,
+                    }
+                    for p in t.params
+                ],
+            }
+            for t in all_templates()
+        ]
+    }
+
+
+@router.post("/run")
+async def run_query(
+    body: QueryRunRequest,
+    current_user: dict = Depends(require_capability("clinical_query")),
+):
+    """Run a registered query template, scoped to the caller's workspace,
+    and return every row with its provenance resolved (openable scan or
+    visible unresolvable marker) plus the cohort-level unresolvable_count.
+    """
+    _enforce_rate_limit(current_user.get("email") or "anonymous")
+
+    workspace_id = current_user.get("workspace_id")
+    if not workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No workspace context",
+        )
+
+    supabase = _sb()
+
+    try:
+        result = run_template(
+            supabase,
+            body.template_id,
+            body.params or {},
+            workspace_id=workspace_id,
+        )
+    except QueryError as qe:
+        raise HTTPException(
+            status_code=_CODE_TO_STATUS.get(qe.code, _DEFAULT_ERROR_STATUS),
+            detail={
+                "error": qe.code,
+                "message": qe.message,
+                "context": qe.context,
+            },
+        )
+
+    # The safe/unsafe difference: a result NEVER leaves this process
+    # without provenance resolved. resolve_provenance does not raise on a
+    # missing/odd document — it renders it visibly unresolvable.
+    resolved = resolve_provenance(
+        supabase, result, workspace_id=workspace_id
+    )
+    return resolved.to_dict()

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ from app.services.storage import StorageManager
 # Import GP router
 from app.api.gp_endpoints import gp_router
 from app.api.clinical_actions import router as clinical_actions_router
+from app.api.query import router as query_router
 
 # Import Ontology router (introspectable schema for codegen / docs)
 from app.api.ontology import ontology_router
@@ -124,6 +125,9 @@ app.include_router(ontology_router)
 # Include PR 3 clinical-actions router (void prescription, soft-delete
 # patient, reassign document, merge patient, universal reverse).
 app.include_router(clinical_actions_router)
+
+# Include Phase-3 query-layer router (POST /api/query/run) — PR A.
+app.include_router(query_router)
 
 if not settings.DEBUG:
     app.add_middleware(

--- a/backend/migrations/024_query_layer_diagnosis_template.sql
+++ b/backend/migrations/024_query_layer_diagnosis_template.sql
@@ -1,0 +1,95 @@
+-- ============================================================================
+-- Migration 024 — Query layer: query_patients_with_diagnosis_prefix (PR 6)
+-- ============================================================================
+--
+-- The first compiled query template. Backs the
+-- `patients_with_diagnosis_prefix` registry entry. Establishes the
+-- pattern every later query RPC repeats:
+--
+--   * STABLE, LANGUAGE sql/plpgsql. Pure read — never mutates, never
+--     audited (queries are not actions; no action_audit_log row).
+--   * p_workspace_id is the MANDATORY first parameter. The Python
+--     runner supplies it from the trusted auth context, never from
+--     caller params. Tenant scoping is structural: the WHERE clause
+--     filters patients.workspace_id = p_workspace_id, so a query
+--     physically cannot return another practice's patients.
+--   * Returns a TABLE(... provenance jsonb). The provenance object is
+--     built IN THE SAME JOIN that produced the fact (diagnoses row →
+--     its source_document_id) — never re-derived afterwards, which
+--     would risk attributing the wrong document. Verified to
+--     round-trip through supabase-py .rpc() as a Python dict
+--     (scripts/verify_query_phase0.py, PR 6 Phase 0).
+--
+-- IDENTIFIER NOTE (migration-015 scar): patients.id and
+-- diagnoses.patient_id are both TEXT in the live schema. The join is
+-- TEXT = TEXT with NO ::uuid cast. Verified by the Phase-0 probe.
+--
+-- ============================================================================
+-- POSTGREST SCHEMA-CACHE — DO NOT REMOVE THE NOTIFY AT THE BOTTOM.
+--
+-- Phase-0 finding: a function created via the psycopg2 DATABASE_URL
+-- path is INVISIBLE to PostgREST's .rpc() until PostgREST reloads its
+-- schema cache. Without the trailing `NOTIFY pgrst, 'reload schema'`
+-- the first call to this template 404s with PGRST202 until the cache
+-- happens to refresh. Every query-template migration MUST end with it.
+-- After applying, allow a few seconds before the RPC is callable.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION query_patients_with_diagnosis_prefix(
+    p_workspace_id  TEXT,
+    p_icd10_prefix  TEXT,
+    p_limit         INT DEFAULT 100
+)
+RETURNS TABLE(
+    patient_id        TEXT,
+    first_name        TEXT,
+    last_name         TEXT,
+    dob               TEXT,
+    diagnosis_code    TEXT,
+    diagnosis_display TEXT,
+    provenance        JSONB
+)
+LANGUAGE sql STABLE AS $$
+    SELECT
+        p.id,
+        p.first_name,
+        p.last_name,
+        p.dob,
+        d.code,
+        d.display,
+        jsonb_build_object(
+            'source_kind',        'diagnosis',
+            -- NULL source_document_id is allowed iff the fact was
+            -- entered live (no scan). The result contract enforces
+            -- that pairing; here we surface whatever the row has.
+            'source_document_id', d.source_document_id,
+            'occurred_on',        d.diagnosed_date,
+            'snippet',            d.code || COALESCE(' — ' || d.display, ''),
+            'page',               NULL
+        ) AS provenance
+    FROM patients p
+    JOIN diagnoses d
+      ON d.patient_id = p.id                         -- TEXT = TEXT, no cast
+    WHERE p.workspace_id = p_workspace_id             -- structural tenant scope
+      AND p.deleted_at IS NULL                        -- migration 020 soft-delete
+      AND d.code IS NOT NULL
+      AND d.code LIKE p_icd10_prefix || '%'           -- p_icd10_prefix validated
+                                                      -- caller-side (no LIKE
+                                                      -- metacharacters reach here)
+    ORDER BY p.last_name, p.first_name
+    LIMIT GREATEST(1, LEAST(p_limit, 500))
+$$;
+
+COMMENT ON FUNCTION query_patients_with_diagnosis_prefix(TEXT, TEXT, INT) IS
+    'PR 6 query layer. Patients whose diagnosis ICD-10 code starts with '
+    'p_icd10_prefix, scoped to p_workspace_id. STABLE read-only; every '
+    'row carries provenance built from the diagnoses source document. '
+    'Backed by the patients_with_diagnosis_prefix registry template.';
+
+-- Phase-0 finding — MANDATORY. See header. Without this the template's
+-- first .rpc() call 404s (PGRST202) until PostgREST refreshes.
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/backend/migrations/025_query_capability_seed.sql
+++ b/backend/migrations/025_query_capability_seed.sql
@@ -1,0 +1,123 @@
+-- ============================================================================
+-- Migration 025 — Seed the `clinical_query` capability (Phase 3, PR A)
+-- ============================================================================
+--
+-- The Phase-3 query layer's HTTP surface (POST /api/query/run) is the
+-- highest-blast-radius READ capability in the system: it runs
+-- cross-cutting clinical cohort queries over a whole practice. Locked
+-- decision #4 of the Phase-3 plan: it is an EXPLICIT-GRANT capability,
+-- NOT in the foundation set — exactly the posture migration 023 took for
+-- `patient_admin`. A capability that can enumerate a practice's clinical
+-- cohorts must not be default-granted the moment it becomes
+-- HTTP-reachable.
+--
+-- Schema (unchanged, from seeds/products_and_capabilities.sql; confirmed
+-- live by migration 023):
+--
+--   capabilities(id TEXT PK, display_name TEXT, description TEXT, created_at)
+--   product_capabilities(product_id TEXT, capability_id TEXT, PK pair)
+--
+-- PRODUCT MAPPING — chosen on a COHERENCE argument, NOT a demo-
+-- enablement one. This distinction is load-bearing; read it before
+-- editing the VALUES list.
+--
+--   platform_essential, platform_professional — the practice-platform
+--   tiers, per the migration-023 `patient_admin` precedent.
+--
+--   legacy_full_access_grant — added on COHERENCE grounds. That product
+--   already entails `analytics_cohorts`, `audit_log`, and the
+--   `clinical_ai_*` capabilities (verified live: it is the bundle
+--   `demo-gp-workspace-001` holds). Those are strictly more sensitive
+--   read surfaces than `clinical_query`. A "full access" grant that
+--   includes clinical-AI and analytics cohorts but EXCLUDES the query
+--   layer is not a tighter blast radius — it is an INCOHERENT
+--   entitlement that lies about what "full access" means. `clinical_query`
+--   is added to it to remove that incoherence. That this also lets the
+--   flagship demo practice exercise the query layer is a CONSEQUENCE of
+--   the demo workspace being correctly provisioned on full-access — it
+--   is NOT the reason for the mapping. If the demo workspace were on the
+--   wrong product, the correct fix would be to move the workspace, never
+--   to widen this capability to reach it. Entitlement mappings are
+--   chosen for semantic correctness; workspaces are placed on the
+--   product that matches their role. Do not bend this list toward a
+--   demo.
+--
+--   NOT `foundation_bundle` — explicit grant, never foundation/default
+--   (locked decision #4).
+--
+--   NOT `module_digitisation` — and this exclusion is a WRITTEN CUSTOMER
+--   PROMISE, not merely a precedent. The Type C leave-behind commits in
+--   writing that a digitisation-only practice gets digitisation and
+--   nothing else and is deliberately NOT pushed onto the platform path.
+--   Granting the highest-blast-radius cross-cutting clinical-query
+--   surface to `module_digitisation` would make that written commitment
+--   a lie. This exclusion is regression-guarded by a build-failing CI
+--   ratchet (tests/test_query_layer_invariants.py::
+--   test_module_digitisation_never_entails_clinical_query) — the same
+--   shape as the PR 5 tenant-guard ratchet, but guarding a customer
+--   promise, which makes it more important than a technical invariant,
+--   not less. If a future debugging session is tempted to add a
+--   one-line grant here to reproduce a bug on a digitisation workspace:
+--   move the debugging workspace to a platform product instead.
+--
+-- HONESTY NOTE (construct validity) — CORRECTED against the live DB,
+-- because the first draft of this note asserted something false:
+-- `demo-gp-workspace-001` (the workspace `legacy_full_access_grant`
+-- entitles, i.e. the one this mapping makes able to run queries) has 31
+-- patients but ZERO diagnoses. The one shipped template
+-- (`patients_with_diagnosis_prefix`) therefore returns an EMPTY result
+-- for demo-gp — it exercises neither the openable nor the unresolvable
+-- path over HTTP. The orphaned-source data-quality finding (the
+-- dominant ~62% failure) lives in the `test-workspace-*` tenants; the
+-- resolvable case lives in `typec-workspace-001`. Neither of those is
+-- entitled to `clinical_query` (correctly: typec is module_digitisation,
+-- ratchet-guarded). So: the resolver's safety property
+-- (orphaned ⇒ visibly unresolvable; present ⇒ openable) IS verified
+-- end-to-end against live data by scripts/verify_query_phase0.py probe
+-- (iv) — real RPC, real resolver, real signed-URL minting — and through
+-- the HTTP/auth stack by tests/test_query_api.py. What is NOT achievable
+-- on the current corpus is a single browser click-through that shows a
+-- real openable row AND a real unresolvable row on one screen, because
+-- no single workspace both (a) is entitled to clinical_query and (b)
+-- holds both a resolvable and an orphaned sourced diagnosis. Closing
+-- that gap requires a properly provisioned platform-tier demo workspace
+-- seeded with both shapes — NAMED here, not faked, and not papered over
+-- by bending this entitlement list to a data-bearing workspace.
+--
+-- Idempotent: ON CONFLICT DO NOTHING on both inserts (re-runnable).
+--
+-- POSTGREST SCHEMA-CACHE NOTE — deliberately NO `NOTIFY pgrst` here, and
+-- that omission is a conscious decision, not an oversight. The
+-- `NOTIFY pgrst, 'reload schema'` discipline (Phase-0 finding) exists
+-- because a newly-created FUNCTION is invisible to PostgREST's RPC
+-- surface until its schema cache reloads. Migration 025 creates no
+-- function — it is pure data seeded into existing tables read through
+-- the normal app path (require_capability → practice_capabilities),
+-- never through PostgREST's function cache. Adding NOTIFY here would be
+-- cargo-culting the discipline rather than applying it. Every migration
+-- that DOES add a query RPC (024, and 026 in PR B) must still end with
+-- NOTIFY; this one correctly does not.
+-- ============================================================================
+
+BEGIN;
+
+INSERT INTO capabilities (id, display_name, description) VALUES
+    ('clinical_query',
+     'Clinical Query Layer',
+     'Run registered, tenant-scoped clinical cohort queries '
+     '(POST /api/query/run). Every result row carries verifiable '
+     'provenance. High-blast-radius read surface — explicit grant.')
+ON CONFLICT (id) DO NOTHING;
+
+-- clinical_query — platform tiers (per 023 precedent) + legacy_full_access_grant
+-- (on the coherence argument in the header — that product already entails
+-- strictly more sensitive read surfaces, so excluding query from it is
+-- incoherent, not conservative). Explicit grant; NOT foundation_bundle;
+-- NOT module_digitisation (written Type C promise, CI-ratchet-guarded).
+INSERT INTO product_capabilities (product_id, capability_id) VALUES
+    ('platform_essential',      'clinical_query'),
+    ('platform_professional',   'clinical_query'),
+    ('legacy_full_access_grant', 'clinical_query')
+ON CONFLICT (product_id, capability_id) DO NOTHING;
+
+COMMIT;

--- a/backend/ontology/query/__init__.py
+++ b/backend/ontology/query/__init__.py
@@ -1,0 +1,45 @@
+"""
+ontology.query — the Phase 3 query layer.
+
+A closed registry of named, versioned, parameterised query templates.
+Each template is backed by exactly one reviewed PL/pgSQL function,
+tenant-scoped by construction (workspace_id is a mandatory RPC
+parameter), and provenance-bearing by construction (every result row
+carries the source it came from — enforced as a CI invariant, not a
+convention).
+
+This is deliberately NOT a generic query algebra / fluent ORM. The
+roadmap's `Patient.where(...).has_diagnosis(...)` example is the
+illustrative *texture*; a safe general SQL compiler is a multi-month
+research project with an unbounded attack surface. We deliver the
+ergonomics of that example for a fixed, hand-reviewed template set —
+the same way the action registry grew one reviewed action at a time.
+
+Public surface:
+  - register_template / get_template / all_templates  (registry)
+  - run_template                                      (the one chokepoint)
+  - QueryResult / QueryRow / Provenance               (result contract)
+  - ParamSpec / TemplateSpec                           (declaration types)
+"""
+
+from ontology.query.spec import ParamSpec, TemplateSpec
+from ontology.query.registry import register_template, get_template, all_templates
+from ontology.query.result import Provenance, QueryRow, QueryResult
+from ontology.query.runner import run_template, QueryError
+
+# Side-effect import: populates the registry at package import time
+# (mirrors app.actions importing .registered).
+from ontology.query import registered  # noqa: F401,E402
+
+__all__ = [
+    "ParamSpec",
+    "TemplateSpec",
+    "register_template",
+    "get_template",
+    "all_templates",
+    "Provenance",
+    "QueryRow",
+    "QueryResult",
+    "run_template",
+    "QueryError",
+]

--- a/backend/ontology/query/__init__.py
+++ b/backend/ontology/query/__init__.py
@@ -26,6 +26,15 @@ from ontology.query.spec import ParamSpec, TemplateSpec
 from ontology.query.registry import register_template, get_template, all_templates
 from ontology.query.result import Provenance, QueryRow, QueryResult
 from ontology.query.runner import run_template, QueryError
+from ontology.query.provenance import (
+    resolve_provenance,
+    ResolvedSource,
+    ResolvedRow,
+    ResolvedQueryResult,
+    OPENABLE,
+    UNRESOLVABLE,
+    NO_SOURCE,
+)
 
 # Side-effect import: populates the registry at package import time
 # (mirrors app.actions importing .registered).
@@ -42,4 +51,11 @@ __all__ = [
     "QueryResult",
     "run_template",
     "QueryError",
+    "resolve_provenance",
+    "ResolvedSource",
+    "ResolvedRow",
+    "ResolvedQueryResult",
+    "OPENABLE",
+    "UNRESOLVABLE",
+    "NO_SOURCE",
 ]

--- a/backend/ontology/query/provenance.py
+++ b/backend/ontology/query/provenance.py
@@ -1,0 +1,377 @@
+"""
+Provenance resolution — the safe/unsafe difference for the query layer.
+
+PR #13 made provenance a *structural contract*: every row carries a
+`Provenance` with a `source_document_id` (or is an explicit live_entry).
+That guarantees provenance is **present**. It does NOT guarantee it is
+**verifiable** — and on the live dev corpus 15 of 24 sourced diagnoses
+(62%) carry a `source_document_id` that points at a `digitised_documents`
+row that no longer exists. A query that renders those rows
+authoritatively with a dead "open source" link beside them is the exact
+Phase-3 failure mode: a confident, plausible, wrong-feeling-correct answer
+the clinician trusts.
+
+This module closes that gap. `resolve_provenance()` takes a
+`QueryResult` and turns every row's opaque `source_document_id` into a
+`ResolvedSource` that is one of exactly three honest states:
+
+  - OPENABLE     — the document exists *in this workspace*, a signed URL
+                   was minted, the citation names the real scan.
+  - UNRESOLVABLE — the id does not resolve to a document in this
+                   workspace (missing row, or — structurally — a
+                   cross-tenant id the workspace scope correctly refuses).
+                   This is rendered *visibly*: an explicit reason and a
+                   citation carrying the truncated id, never a blank or a
+                   silent dead link.
+  - NO_SOURCE    — a live_entry: a fact typed straight into the EHR with
+                   no scan. Legitimately sourceless; NOT a failure and
+                   NOT counted as unresolvable.
+
+Two invariants are enforced *structurally* (in `__post_init__`), not by
+convention, so a future change physically cannot reintroduce the unsafe
+shape and the CI test in test_query_layer_invariants.py is asserting a
+property the type already guarantees (defence in depth, the same pattern
+`Provenance` and the runner use):
+
+  1. **No silent dead link.** `openable` is true IFF a signed URL is
+     present. You cannot construct an OPENABLE source without a URL, and
+     a non-OPENABLE source cannot carry one.
+  2. **Row/aggregate signals cannot drift.** `ResolvedQueryResult`
+     refuses to exist unless `unresolvable_count` exactly equals the
+     number of UNRESOLVABLE rows. The aggregate is the signal that gets
+     read at cohort altitude (a 40-row answer where 25 sources are dead
+     is the demo failure; a per-row marker nobody scans does not surface
+     it) — so it must never disagree with the rows it summarises.
+
+Tenant scope is part of the correctness mechanism here, not separate
+from it: the document lookup is `.eq("workspace_id", workspace_id)`, so a
+`source_document_id` that exists only in another practice resolves as
+UNRESOLVABLE rather than leaking another tenant's scan. (Corpus produces
+0 of the cross-tenant case — every one of the 15 missing ids is missing
+globally — so that specific branch is labelled construct-validity-only
+and exercised by a fabricated unit test, never claimed as
+corpus-demonstrated. Design choice #7.)
+
+Citations are honest: `filename` + `upload_date` (+ page when the
+provenance carries one). `doc_type` is 0% populated on the corpus, so a
+citation never claims "referral letter" / "lab report" — it does not
+fabricate a document class it cannot stand behind.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, date
+from typing import Any, Dict, List, Optional
+
+from ontology.query.result import LIVE_ENTRY, Provenance, QueryResult
+
+# Resolution states.
+OPENABLE = "openable"
+UNRESOLVABLE = "unresolvable"
+NO_SOURCE = "no_source"
+_STATES = (OPENABLE, UNRESOLVABLE, NO_SOURCE)
+
+# The Supabase Storage bucket every digitised scan lives in. Same bucket
+# the digitisation validation panel signs from (digitisation.py:268) —
+# reused verbatim so a query-opened scan and a validation-opened scan are
+# the identical object.
+_STORAGE_BUCKET = "medical-records"
+_SIGNED_URL_TTL_S = 3600
+
+
+@dataclass(frozen=True)
+class ResolvedSource:
+    """The verifiable (or honestly-not) form of one row's provenance.
+
+    `status` is one of OPENABLE / UNRESOLVABLE / NO_SOURCE. `openable`
+    is derived, never set independently — so the silent-dead-link guard
+    cannot be bypassed by setting a flag.
+    """
+
+    status: str
+    document_id: Optional[str]
+    signed_url: Optional[str]
+    citation: str
+    unresolvable_reason: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.status not in _STATES:
+            raise ValueError(
+                f"ResolvedSource.status must be one of {_STATES}, "
+                f"got {self.status!r}"
+            )
+        # Invariant 1 — no silent dead link, enforced structurally.
+        if self.status == OPENABLE and not self.signed_url:
+            raise ValueError(
+                "ResolvedSource is OPENABLE but carries no signed_url — "
+                "this is exactly the silent dead link the resolver exists "
+                "to make impossible"
+            )
+        if self.status != OPENABLE and self.signed_url:
+            raise ValueError(
+                f"ResolvedSource is {self.status} but carries a signed_url; "
+                f"only OPENABLE sources may"
+            )
+        if self.status == UNRESOLVABLE and not self.unresolvable_reason:
+            raise ValueError(
+                "UNRESOLVABLE ResolvedSource must carry an explicit "
+                "unresolvable_reason — an unexplained unresolvable is a "
+                "blank, which is the unsafe rendering"
+            )
+        if not self.citation:
+            raise ValueError("ResolvedSource must always carry a citation")
+
+    @property
+    def openable(self) -> bool:
+        return self.status == OPENABLE
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "openable": self.openable,
+            "document_id": self.document_id,
+            "signed_url": self.signed_url,
+            "citation": self.citation,
+            "unresolvable_reason": self.unresolvable_reason,
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedRow:
+    """One answer row with its provenance resolved to a ResolvedSource."""
+
+    data: Dict[str, Any]
+    provenance: Provenance
+    source: ResolvedSource
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            **self.data,
+            "provenance": self.provenance.to_dict(),
+            "source": self.source.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedQueryResult:
+    """The envelope the HTTP surface returns. Carries the cohort-level
+    `unresolvable_count` — the signal that gets read when a clinician
+    scans a 40-row cohort and does not read every per-row citation.
+
+    `unresolvable_count` counts UNRESOLVABLE rows ONLY. NO_SOURCE
+    (live_entry) rows are `openable == False` but are NOT failures;
+    counting them would inflate the dead-link number into its own
+    confident-wrong-answer about how broken the sources are.
+    """
+
+    template_id: str
+    template_version: int
+    workspace_id: str
+    rows: List[ResolvedRow]
+    row_count: int
+    data_maturity: str
+    unresolvable_count: int
+
+    def __post_init__(self) -> None:
+        # Invariant 2 — row/aggregate signals cannot drift. The envelope
+        # physically cannot exist if the aggregate disagrees with the
+        # rows. PR B's superseded_count will add a sibling assertion here.
+        actual = sum(1 for r in self.rows if r.source.status == UNRESOLVABLE)
+        if self.unresolvable_count != actual:
+            raise ValueError(
+                f"unresolvable_count={self.unresolvable_count} disagrees "
+                f"with {actual} UNRESOLVABLE rows — the cohort-level and "
+                f"row-level safety signals must never drift apart"
+            )
+        if self.row_count != len(self.rows):
+            raise ValueError(
+                f"row_count={self.row_count} disagrees with {len(self.rows)} "
+                f"rows"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "template_id": self.template_id,
+            "template_version": self.template_version,
+            "workspace_id": self.workspace_id,
+            "row_count": self.row_count,
+            "data_maturity": self.data_maturity,
+            "unresolvable_count": self.unresolvable_count,
+            "rows": [r.to_dict() for r in self.rows],
+        }
+
+
+def _fmt_date(value: Any) -> Optional[str]:
+    """upload_date comes back from PostgREST as an ISO string. Render it
+    as a human date ('7 May 2026'). Be tolerant of str / datetime / date
+    / None; never raise from citation building."""
+    if value is None:
+        return None
+    if isinstance(value, (datetime, date)):
+        dt = value
+    else:
+        s = str(value).replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(s)
+        except ValueError:
+            try:
+                dt = datetime.fromisoformat(s[:10])
+            except ValueError:
+                return str(value)[:10] or None
+    return f"{dt.day} {dt.strftime('%B %Y')}"
+
+
+def _citation_for_doc(doc: Dict[str, Any], prov: Provenance) -> str:
+    """Honest citation: filename + upload date (+ page if known). No
+    doc_type — it is 0% populated on the corpus; a citation must not
+    assert a document class it cannot stand behind."""
+    filename = doc.get("filename") or "source document"
+    when = _fmt_date(doc.get("upload_date") or doc.get("created_at"))
+    parts = [filename]
+    if when:
+        parts.append(when)
+    if prov.page is not None:
+        parts.append(f"page {prov.page}")
+    return ", ".join(parts)
+
+
+def _short_id(document_id: str) -> str:
+    """Last 6 chars — locked decision #3: a truncated id reads as 'the
+    system knows precisely which record and is telling me it is gone',
+    the honest known-unknown, not a vague system fault."""
+    return document_id[-6:]
+
+
+def _sign(supabase, file_path: Optional[str]) -> Optional[str]:
+    """Mint a signed URL, mirroring digitisation.py:268 exactly so a
+    query-opened scan is the same object as a validation-opened scan.
+    Returns None on any failure — the caller turns None into a *visible*
+    UNRESOLVABLE, never a silent dead link."""
+    if not file_path:
+        return None
+    try:
+        signed = supabase.storage.from_(_STORAGE_BUCKET).create_signed_url(
+            path=file_path,
+            expires_in=_SIGNED_URL_TTL_S,
+        )
+    except Exception:  # noqa: BLE001 — any storage failure ⇒ visible unresolvable
+        return None
+    if not isinstance(signed, dict):
+        return None
+    return signed.get("signedURL") or signed.get("signed_url")
+
+
+def resolve_provenance(
+    supabase,
+    result: QueryResult,
+    *,
+    workspace_id: str,
+) -> ResolvedQueryResult:
+    """Resolve every row's provenance to a ResolvedSource.
+
+    One workspace-scoped batch query against `digitised_documents` (the
+    `.eq("workspace_id", workspace_id)` is both the correctness join and
+    the tenant scope — a cross-practice id resolves UNRESOLVABLE, never
+    leaks). Signed URLs are minted per resolvable doc.
+
+    Never raises on a missing/odd document: the whole point is that the
+    unresolvable path is *first-class and visible*, not an exception or a
+    blank.
+    """
+    if not workspace_id:
+        # Defence in depth behind the runner (which already refuses an
+        # unscoped query): a resolver without a workspace could only
+        # produce an unscoped document lookup.
+        raise ValueError(
+            "resolve_provenance requires a workspace_id from the trusted "
+            "caller context; refusing an unscoped document lookup"
+        )
+
+    needed = sorted(
+        {
+            r.provenance.source_document_id
+            for r in result.rows
+            if r.provenance.source_document_id
+            and r.provenance.source_kind != LIVE_ENTRY
+        }
+    )
+
+    docs: Dict[str, Dict[str, Any]] = {}
+    if needed:
+        resp = (
+            supabase.table("digitised_documents")
+            .select("id, filename, file_path, upload_date, created_at")
+            .in_("id", needed)
+            .eq("workspace_id", workspace_id)  # tenant scope == correctness
+            .execute()
+        )
+        for d in (getattr(resp, "data", None) or []):
+            docs[d["id"]] = d
+
+    resolved: List[ResolvedRow] = []
+    for row in result.rows:
+        prov = row.provenance
+        doc_id = prov.source_document_id
+
+        if prov.source_kind == LIVE_ENTRY or not doc_id:
+            source = ResolvedSource(
+                status=NO_SOURCE,
+                document_id=None,
+                signed_url=None,
+                citation="entered directly in the EHR (no source document)",
+            )
+        else:
+            doc = docs.get(doc_id)
+            if doc is None:
+                # The dominant 62% case, OR a cross-tenant id the
+                # workspace scope correctly refused. Either way: visible.
+                source = ResolvedSource(
+                    status=UNRESOLVABLE,
+                    document_id=doc_id,
+                    signed_url=None,
+                    citation=(
+                        f"source document no longer available "
+                        f"(id …{_short_id(doc_id)})"
+                    ),
+                    unresolvable_reason="source_document_not_found_in_workspace",
+                )
+            else:
+                url = _sign(supabase, doc.get("file_path"))
+                if not url:
+                    # Found the row but cannot retrieve the object right
+                    # now — STILL visible, STILL not a silent dead link.
+                    source = ResolvedSource(
+                        status=UNRESOLVABLE,
+                        document_id=doc_id,
+                        signed_url=None,
+                        citation=(
+                            f"source document found but not retrievable "
+                            f"right now (id …{_short_id(doc_id)})"
+                        ),
+                        unresolvable_reason="signed_url_unavailable",
+                    )
+                else:
+                    source = ResolvedSource(
+                        status=OPENABLE,
+                        document_id=doc_id,
+                        signed_url=url,
+                        citation=_citation_for_doc(doc, prov),
+                    )
+
+        resolved.append(
+            ResolvedRow(data=row.data, provenance=prov, source=source)
+        )
+
+    unresolvable_count = sum(
+        1 for r in resolved if r.source.status == UNRESOLVABLE
+    )
+    return ResolvedQueryResult(
+        template_id=result.template_id,
+        template_version=result.template_version,
+        workspace_id=workspace_id,
+        rows=resolved,
+        row_count=len(resolved),
+        data_maturity=result.data_maturity,
+        unresolvable_count=unresolvable_count,
+    )

--- a/backend/ontology/query/registered.py
+++ b/backend/ontology/query/registered.py
@@ -1,0 +1,16 @@
+"""
+Query-template registration sentinel.
+
+Importing this module fires register_template() for every template in
+ontology/query/templates/. Mirrors app/actions/registered.py.
+
+To add a query shape:
+  1. Write ontology/query/templates/<shape>.py with a
+     register_template(TemplateSpec(...)) call.
+  2. Write its PL/pgSQL function in the next migration, ending the
+     migration with NOTIFY pgrst, 'reload schema' (Phase-0 finding —
+     without it the RPC is invisible to PostgREST until cache reload).
+  3. Add one import line below.
+"""
+
+from ontology.query.templates import patients_with_diagnosis_prefix  # noqa: F401

--- a/backend/ontology/query/registry.py
+++ b/backend/ontology/query/registry.py
@@ -1,0 +1,49 @@
+"""
+The query template registry.
+
+Mirrors the action registry pattern (app/actions/registry.py): modules
+under ontology/query/templates/ call register_template() at import
+time; ontology/query/registered.py imports them all so the registry is
+populated at package import.
+
+A template can only enter the registry if it declares a provenance
+output column (enforced by TemplateSpec.__post_init__) — so "every
+answer has a source" is impossible to violate by construction, not by
+review vigilance.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ontology.query.spec import TemplateSpec
+
+_REGISTRY: Dict[str, TemplateSpec] = {}
+
+
+def register_template(spec: TemplateSpec) -> TemplateSpec:
+    if spec.id in _REGISTRY:
+        existing = _REGISTRY[spec.id]
+        if existing.version == spec.version:
+            raise RuntimeError(
+                f"query template {spec.id!r} v{spec.version} already "
+                f"registered — duplicate registration"
+            )
+        # Higher version supersedes; keep the newest.
+        if spec.version < existing.version:
+            return existing
+    _REGISTRY[spec.id] = spec
+    return spec
+
+
+def get_template(template_id: str) -> TemplateSpec:
+    if template_id not in _REGISTRY:
+        raise KeyError(
+            f"unknown query template {template_id!r}. "
+            f"Known: {sorted(_REGISTRY)}"
+        )
+    return _REGISTRY[template_id]
+
+
+def all_templates() -> List[TemplateSpec]:
+    return sorted(_REGISTRY.values(), key=lambda s: s.id)

--- a/backend/ontology/query/result.py
+++ b/backend/ontology/query/result.py
@@ -1,0 +1,95 @@
+"""
+The query result contract — frozen.
+
+Every row from every template carries a Provenance. This is the
+structural expression of the roadmap's "provenance in every answer":
+"Mrs Khumalo: HbA1c 8.9% (Lancet lab report, 8 March 2026, page 1)"
+with a one-click link to the source scan.
+
+`source_document_id` may be None ONLY when `source_kind == 'live_entry'`
+— a fact a clinician typed directly into the EHR has no source scan.
+The contract makes that explicit and honest rather than fabricating a
+document id. The runner enforces this invariant on every row.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+LIVE_ENTRY = "live_entry"
+
+
+@dataclass(frozen=True)
+class Provenance:
+    source_kind: str                       # 'diagnosis'|'prescription'|'vital'|'live_entry'|...
+    source_document_id: Optional[str] = None
+    occurred_on: Optional[str] = None      # ISO date the fact was recorded/observed
+    snippet: Optional[str] = None          # short human context (e.g. the ICD code)
+    page: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.source_document_id is None and self.source_kind != LIVE_ENTRY:
+            raise ValueError(
+                f"provenance with no source_document_id must have "
+                f"source_kind={LIVE_ENTRY!r}, got {self.source_kind!r} — "
+                f"refusing to present a sourced fact with no source"
+            )
+
+    @classmethod
+    def from_jsonb(cls, blob: Optional[Dict[str, Any]]) -> "Provenance":
+        """Build from the jsonb the RPC returns. A row arriving with no
+        provenance object at all is a template bug (the CI invariant
+        test exists to prevent it ever shipping) — fail loud here too."""
+        if not isinstance(blob, dict):
+            raise ValueError(
+                f"row arrived without a provenance object "
+                f"(got {type(blob).__name__}) — the template's RPC must "
+                f"build provenance in the same join that produced the fact"
+            )
+        return cls(
+            source_kind=blob.get("source_kind") or LIVE_ENTRY,
+            source_document_id=blob.get("source_document_id"),
+            occurred_on=blob.get("occurred_on"),
+            snippet=blob.get("snippet"),
+            page=blob.get("page"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source_kind": self.source_kind,
+            "source_document_id": self.source_document_id,
+            "occurred_on": self.occurred_on,
+            "snippet": self.snippet,
+            "page": self.page,
+        }
+
+
+@dataclass(frozen=True)
+class QueryRow:
+    """One answer row: the data columns + its mandatory provenance."""
+    data: Dict[str, Any]              # all non-provenance columns
+    provenance: Provenance
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {**self.data, "provenance": self.provenance.to_dict()}
+
+
+@dataclass(frozen=True)
+class QueryResult:
+    template_id: str
+    template_version: int
+    workspace_id: str
+    rows: List[QueryRow]
+    row_count: int
+    data_maturity: str = "populated"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "template_id": self.template_id,
+            "template_version": self.template_version,
+            "workspace_id": self.workspace_id,
+            "row_count": self.row_count,
+            "data_maturity": self.data_maturity,
+            "rows": [r.to_dict() for r in self.rows],
+        }

--- a/backend/ontology/query/runner.py
+++ b/backend/ontology/query/runner.py
@@ -1,0 +1,152 @@
+"""
+run_template() — the single chokepoint every query flows through.
+
+Responsibilities, in order:
+  1. Resolve the template from the registry.
+  2. Validate caller params against the typed schema (reject unknown
+     params; coerce/validate declared ones).
+  3. Inject workspace_id as the mandatory first RPC arg — taken from
+     the trusted caller context, NEVER from caller-supplied params.
+     This is the tenant-scoping invariant: a query physically cannot
+     run unscoped because the runner always supplies p_workspace_id.
+  4. Call the backing PL/pgSQL function via supabase.rpc().
+  5. Map RPC SQLSTATEs to typed QueryError (reusing the action layer's
+     classifier so the vocabulary is consistent platform-wide).
+  6. Wrap every row in QueryRow with its mandatory Provenance — a row
+     that comes back without provenance is a template bug and raises
+     here (defence in depth behind the CI invariant test).
+
+This is also the one place a future POPIA access-log decorator would
+attach (deliberately deferred — Phase 5 — but the chokepoint exists so
+it's a decorator, not a refactor).
+
+Note: per the Phase-0 finding, a freshly-migrated template RPC is
+invisible to PostgREST until its schema cache reloads. Callers hitting
+a brand-new template may see QueryError(code='template_unavailable');
+the migration that ships a template issues NOTIFY pgrst + the deploy
+waits. Not retried here — a cold cache in normal operation is an
+operational fault, not a per-request condition to paper over.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ontology.query.registry import get_template
+from ontology.query.result import Provenance, QueryResult, QueryRow
+from ontology.query.spec import PROVENANCE_COLUMN
+
+
+class QueryError(Exception):
+    def __init__(self, code: str, message: str, context: Dict[str, Any] | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.context = context or {}
+
+
+def run_template(
+    supabase,
+    template_id: str,
+    params: Dict[str, Any],
+    *,
+    workspace_id: str,
+) -> QueryResult:
+    if not workspace_id:
+        # The runner is the tenant-scoping invariant. No workspace =
+        # no query, full stop. (Mirrors the PR 5 guard's intent at
+        # runtime.)
+        raise QueryError(
+            "missing_workspace",
+            "run_template requires a workspace_id from the trusted "
+            "caller context; refusing to run an unscoped query",
+        )
+
+    try:
+        spec = get_template(template_id)
+    except KeyError as e:
+        raise QueryError("unknown_template", str(e), {"template_id": template_id})
+
+    # Reject unknown params (typo / injection-shaped input fails closed).
+    declared = {p.name for p in spec.params}
+    unknown = set(params) - declared
+    if unknown:
+        raise QueryError(
+            "unknown_param",
+            f"unknown parameter(s) {sorted(unknown)} for template "
+            f"{template_id!r}; accepts {sorted(declared)}",
+            {"template_id": template_id},
+        )
+
+    # Build the RPC kwargs: workspace first (trusted), then validated params.
+    rpc_kwargs: Dict[str, Any] = {"p_workspace_id": workspace_id}
+    for p in spec.params:
+        try:
+            value = p.coerce_and_validate(params.get(p.name))
+        except ValueError as ve:
+            raise QueryError("invalid_param", str(ve), {"param": p.name})
+        rpc_kwargs[p.rpc_arg] = value
+
+    # Execute.
+    try:
+        resp = supabase.rpc(spec.rpc_name, rpc_kwargs).execute()
+    except Exception as exc:  # noqa: BLE001
+        # Reuse the action layer's SQLSTATE/HINT → code classifier so the
+        # error vocabulary is identical across mutations and queries.
+        from app.actions.primitives import _classify_rpc_error
+        ed = _classify_rpc_error(exc)
+        text = str(exc)
+        if "PGRST202" in text:
+            raise QueryError(
+                "template_unavailable",
+                f"template {template_id!r} RPC {spec.rpc_name!r} not in "
+                f"PostgREST schema cache — migration must NOTIFY pgrst "
+                f"and the deploy must wait for reload",
+                {"template_id": template_id, "rpc": spec.rpc_name},
+            )
+        raise QueryError(ed.code, ed.message, ed.context)
+
+    raw = resp.data if hasattr(resp, "data") else resp
+    if raw is None:
+        raw = []
+    if not isinstance(raw, list):
+        raise QueryError(
+            "bad_rpc_shape",
+            f"template {template_id!r} RPC returned "
+            f"{type(raw).__name__}, expected a list of rows",
+            {"template_id": template_id},
+        )
+
+    rows = []
+    for r in raw:
+        if not isinstance(r, dict):
+            raise QueryError(
+                "bad_rpc_shape",
+                f"template {template_id!r} returned a non-dict row "
+                f"({type(r).__name__})",
+                {"template_id": template_id},
+            )
+        prov_blob = r.get(PROVENANCE_COLUMN)
+        try:
+            prov = Provenance.from_jsonb(prov_blob)
+        except ValueError as ve:
+            # Defence in depth behind the CI invariant test: a template
+            # whose SQL forgot to build provenance fails loud at runtime
+            # rather than silently returning sourceless answers.
+            raise QueryError(
+                "provenance_missing",
+                f"template {template_id!r} row missing/invalid "
+                f"provenance: {ve}",
+                {"template_id": template_id},
+            )
+        data = {k: v for k, v in r.items() if k != PROVENANCE_COLUMN}
+        rows.append(QueryRow(data=data, provenance=prov))
+
+    return QueryResult(
+        template_id=spec.id,
+        template_version=spec.version,
+        workspace_id=workspace_id,
+        rows=rows,
+        row_count=len(rows),
+        data_maturity=spec.data_maturity,
+    )

--- a/backend/ontology/query/spec.py
+++ b/backend/ontology/query/spec.py
@@ -1,0 +1,102 @@
+"""
+Query template declaration types.
+
+A TemplateSpec is the typed contract of one query shape:
+  - a stable id + version
+  - the PL/pgSQL function that executes it (tenant-scoped)
+  - its typed parameter schema (ParamSpec list)
+  - its declared output columns — which MUST include 'provenance'
+    (enforced by register_template and the CI invariant test)
+
+This is intentionally lightweight metadata, not a SQL IR. Per the
+Phase 3 design (closed registry, not a generic algebra) the actual
+query lives in a hand-reviewed PL/pgSQL function; this just describes
+its shape so params can be validated and the provenance contract
+enforced before the RPC is ever called.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Optional
+
+
+# The column every template's RPC MUST return per row. Enforced at
+# registration time and by test_query_layer_unit.py — "every answer
+# carries its source" is a structural property, not a convention.
+PROVENANCE_COLUMN = "provenance"
+
+# workspace_id is always the first RPC arg, supplied by the runner from
+# the auth context — never by the caller. Templates declare it
+# implicitly; param specs are the *caller-supplied* params only.
+WORKSPACE_PARAM = "p_workspace_id"
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """One caller-supplied parameter of a query template.
+
+    `py_type` is the Python type the runner validates against.
+    `rpc_arg` is the PL/pgSQL function's parameter name (e.g.
+    'p_icd10_prefix'). `validator` is an optional extra check that
+    raises ValueError with a human message on bad input.
+    """
+    name: str
+    py_type: type
+    rpc_arg: str
+    required: bool = True
+    default: Any = None
+    validator: Optional[Callable[[Any], None]] = None
+
+    def coerce_and_validate(self, raw: Any) -> Any:
+        if raw is None:
+            if self.required:
+                raise ValueError(f"missing required parameter {self.name!r}")
+            return self.default
+        # Light coercion: ints arriving as numeric strings, etc.
+        if self.py_type is int and isinstance(raw, str) and raw.lstrip("-").isdigit():
+            raw = int(raw)
+        if not isinstance(raw, self.py_type):
+            raise ValueError(
+                f"parameter {self.name!r} must be {self.py_type.__name__}, "
+                f"got {type(raw).__name__}"
+            )
+        if self.validator is not None:
+            self.validator(raw)  # raises ValueError on failure
+        return raw
+
+
+@dataclass(frozen=True)
+class TemplateSpec:
+    """The full declaration of one query shape."""
+    id: str
+    version: int
+    rpc_name: str
+    params: List[ParamSpec]
+    output_columns: List[str]
+    description: str = ""
+    # Honest documentation surface: if the shape is correct but the
+    # underlying data is thin/absent on the current corpus (e.g. the
+    # lab-threshold shape — schema-correct, ~0 rows until lab ingestion
+    # exists), say so here. Surfaced in the registry, never hidden.
+    data_maturity: str = "populated"  # 'populated' | 'thin' | 'schema_only'
+
+    def __post_init__(self) -> None:
+        if PROVENANCE_COLUMN not in self.output_columns:
+            raise ValueError(
+                f"template {self.id!r} must declare a {PROVENANCE_COLUMN!r} "
+                f"output column — every answer must carry its source. "
+                f"Declared columns: {self.output_columns}"
+            )
+        if not self.rpc_name.startswith("query_"):
+            raise ValueError(
+                f"template {self.id!r} rpc_name {self.rpc_name!r} must start "
+                f"with 'query_' (namespacing convention; keeps query RPCs "
+                f"visually distinct from action RPCs like "
+                f"execute_action_*)"
+            )
+        seen = set()
+        for p in self.params:
+            if p.name in seen:
+                raise ValueError(f"duplicate param {p.name!r} in template {self.id!r}")
+            seen.add(p.name)

--- a/backend/ontology/query/templates/patients_with_diagnosis_prefix.py
+++ b/backend/ontology/query/templates/patients_with_diagnosis_prefix.py
@@ -1,0 +1,73 @@
+"""
+Template: patients_with_diagnosis_prefix
+
+"Which patients in this practice have a diagnosis whose ICD-10 code
+starts with <prefix>?"  e.g. 'E11' → type-2 diabetes cohort,
+'I10' → hypertension cohort.
+
+Chosen as PR 6's single proven shape because diagnoses is the
+best-populated coded clinical table on the dev corpus (code reliably
+set, indexed) and it exercises the Patient⋈Diagnosis join plus
+provenance sourced from diagnoses.source_document_id — the exact
+pattern every later template repeats.
+
+Backed by query_patients_with_diagnosis_prefix (migration 024).
+"""
+
+from __future__ import annotations
+
+from ontology.query.registry import register_template
+from ontology.query.spec import ParamSpec, TemplateSpec
+
+
+def _validate_icd10_prefix(v: str) -> None:
+    s = v.strip()
+    if not s:
+        raise ValueError("icd10_prefix must be non-empty")
+    if len(s) > 8:
+        raise ValueError("icd10_prefix too long (max 8 chars)")
+    # ICD-10 codes are alnum + dot; reject anything that could be a
+    # LIKE/SQL metacharacter (defence in depth — the RPC also
+    # parameterises, but fail closed at the edge).
+    if any(c in s for c in "%_\\'\";"):
+        raise ValueError("icd10_prefix contains illegal characters")
+
+
+def _validate_limit(v: int) -> None:
+    if v < 1 or v > 500:
+        raise ValueError("limit must be between 1 and 500")
+
+
+register_template(TemplateSpec(
+    id="patients_with_diagnosis_prefix",
+    version=1,
+    rpc_name="query_patients_with_diagnosis_prefix",
+    description="Patients whose diagnosis ICD-10 code starts with a prefix.",
+    data_maturity="populated",
+    params=[
+        ParamSpec(
+            name="icd10_prefix",
+            py_type=str,
+            rpc_arg="p_icd10_prefix",
+            required=True,
+            validator=_validate_icd10_prefix,
+        ),
+        ParamSpec(
+            name="limit",
+            py_type=int,
+            rpc_arg="p_limit",
+            required=False,
+            default=100,
+            validator=_validate_limit,
+        ),
+    ],
+    output_columns=[
+        "patient_id",
+        "first_name",
+        "last_name",
+        "dob",
+        "diagnosis_code",
+        "diagnosis_display",
+        "provenance",
+    ],
+))

--- a/backend/scripts/verify_query_phase0.py
+++ b/backend/scripts/verify_query_phase0.py
@@ -211,6 +211,128 @@ conn.close()
 ok("probe function dropped (no residue)")
 
 # ---------------------------------------------------------------------------
+# Probe (iv) — PR A RESOLUTION probe. The single highest-priority check
+# in Phase 3, in live form: the dominant 62% orphaned-source corpus
+# failure must render VISIBLY UNRESOLVABLE (explicit reason + truncated
+# id in the citation), never a blank or a silent dead link — AND a
+# genuinely present source must render OPENABLE with a real signed URL.
+# Read-only: run_template is STABLE; resolve_provenance does select +
+# create_signed_url. No writes.
+# ---------------------------------------------------------------------------
+print("\n(iv) PR A — provenance resolution: orphaned ⇒ visibly "
+      "unresolvable, present ⇒ openable")
+
+from ontology.query import (  # noqa: E402
+    run_template, resolve_provenance, QueryError, OPENABLE, UNRESOLVABLE,
+)
+
+sb2 = create_client(SB_URL, SB_KEY)
+
+# Grounded in the live probe done while writing PR A:
+#   typec-workspace-001  has doc 1ea97a59 (Patient file.pdf), 0 orphaned;
+#                         diagnoses incl. J06.9  → RESOLVABLE path.
+#   test-workspace-c9f4d540  has 1 diagnosis I10 whose source_document_id
+#                         …e15a71 is missing globally → UNRESOLVABLE path.
+RESOLVABLE_WS = "typec-workspace-001"
+RESOLVABLE_PREFIX = "J06"
+ORPHANED_WS = "test-workspace-c9f4d540"
+ORPHANED_PREFIX = "I10"
+
+
+def _run_with_cache_retry(ws, prefix):
+    """The template RPC may 404 (PGRST202) until PostgREST's schema cache
+    reloads after migration 024's NOTIFY. A verification script is
+    allowed to be patient; production is not (runner does not retry)."""
+    last = None
+    for attempt in range(6):
+        try:
+            return run_template(
+                sb2, "patients_with_diagnosis_prefix",
+                {"icd10_prefix": prefix}, workspace_id=ws,
+            )
+        except QueryError as qe:
+            last = qe
+            if qe.code in ("template_unavailable",):
+                time.sleep(4)
+                continue
+            raise
+    raise last or RuntimeError("rpc never resolved")
+
+
+try:
+    res_ok = _run_with_cache_retry(RESOLVABLE_WS, RESOLVABLE_PREFIX)
+    if res_ok.row_count == 0:
+        bad(f"resolvable probe: 0 rows for {RESOLVABLE_WS}/{RESOLVABLE_PREFIX} "
+            f"— corpus changed; pick another present-source workspace")
+    else:
+        resolved_ok = resolve_provenance(
+            sb2, res_ok, workspace_id=RESOLVABLE_WS
+        )
+        openable = [r for r in resolved_ok.rows
+                    if r.source.status == OPENABLE]
+        if openable and openable[0].source.signed_url:
+            ok(f"present source ⇒ OPENABLE with signed URL; "
+               f"citation={openable[0].source.citation!r}")
+        else:
+            bad("present source did NOT resolve to an openable signed URL "
+                "— the resolvable path is broken")
+        if resolved_ok.unresolvable_count == 0:
+            ok(f"{RESOLVABLE_WS} unresolvable_count == 0 (expected; "
+               f"0 orphaned there)")
+        else:
+            print(f"  ⚠ {RESOLVABLE_WS} unresolvable_count="
+                  f"{resolved_ok.unresolvable_count} (corpus drift; not a "
+                  f"PR A blocker — the openable assertion is the gate)")
+except QueryError as qe:
+    bad(f"resolvable probe raised QueryError({qe.code!r}: {qe.message}). "
+        f"If unknown_template/template_unavailable: apply migration 024 "
+        f"and wait for the PostgREST schema-cache reload before smoke.")
+except Exception as e:  # noqa: BLE001
+    bad(f"resolvable probe raised {e!r}")
+
+try:
+    res_orphan = _run_with_cache_retry(ORPHANED_WS, ORPHANED_PREFIX)
+    if res_orphan.row_count == 0:
+        bad(f"orphaned probe: 0 rows for {ORPHANED_WS}/{ORPHANED_PREFIX} "
+            f"— corpus changed; the 15/24 finding must be re-grounded")
+    else:
+        resolved_orphan = resolve_provenance(
+            sb2, res_orphan, workspace_id=ORPHANED_WS
+        )
+        unr = [r for r in resolved_orphan.rows
+               if r.source.status == UNRESOLVABLE]
+        if not unr:
+            bad("orphaned probe: the known-missing source resolved as "
+                "something OTHER than UNRESOLVABLE — the dominant 62% "
+                "corpus failure is being rendered authoritatively. THIS "
+                "is the Phase-3 unsafe artifact.")
+        else:
+            s = unr[0].source
+            visible = (s.signed_url is None
+                       and s.unresolvable_reason ==
+                       "source_document_not_found_in_workspace"
+                       and "…" in s.citation
+                       and "no longer available" in s.citation)
+            if visible:
+                ok(f"orphaned source ⇒ VISIBLY UNRESOLVABLE; "
+                   f"citation={s.citation!r}")
+            else:
+                bad(f"orphaned source unresolvable but NOT visibly so: "
+                    f"citation={s.citation!r} reason="
+                    f"{s.unresolvable_reason!r} url={s.signed_url!r}")
+        if resolved_orphan.unresolvable_count >= 1:
+            ok(f"cohort signal present: unresolvable_count="
+               f"{resolved_orphan.unresolvable_count} "
+               f"(read at cohort altitude, not buried per-row)")
+        else:
+            bad("unresolvable_count is 0 despite an unresolvable row — "
+                "the row/aggregate consistency invariant is violated")
+except QueryError as qe:
+    bad(f"orphaned probe raised QueryError({qe.code!r}: {qe.message})")
+except Exception as e:  # noqa: BLE001
+    bad(f"orphaned probe raised {e!r}")
+
+# ---------------------------------------------------------------------------
 print("\n" + "=" * 64)
 if FAIL:
     print("PHASE-0 OUTCOME: compile-to-RPC strategy NOT confirmed.")
@@ -222,8 +344,10 @@ if FAIL:
     for f in FAIL:
         print(f"  - {f}")
     sys.exit(1)
-print("PHASE-0 OUTCOME: compile-to-RPC strategy CONFIRMED.")
-print("STABLE TABLE(... jsonb) functions round-trip through supabase-py")
-print(".rpc() as typed dict rows. Proceed with the RPC-backed query")
-print("layer exactly as planned.")
+print("PHASE-0 OUTCOME: compile-to-RPC strategy CONFIRMED + PR A")
+print("resolution VERIFIED. STABLE TABLE(... jsonb) functions round-trip")
+print("through supabase-py .rpc() as typed dict rows; a present source")
+print("resolves OPENABLE with a signed URL; the dominant orphaned-source")
+print("corpus failure resolves VISIBLY UNRESOLVABLE (explicit reason +")
+print("truncated id), never a silent dead link. PR A is safe to smoke.")
 sys.exit(0)

--- a/backend/scripts/verify_query_phase0.py
+++ b/backend/scripts/verify_query_phase0.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+PR 6 Phase-0 verification — the load-bearing check before the query
+layer's compile-to-RPC strategy is committed to.
+
+Run:  cd backend && PYTHONPATH=. .venv/bin/python scripts/verify_query_phase0.py
+
+THREE PROBES, all read-only / self-cleaning:
+
+  (i)  THE LOAD-BEARING ONE. A STABLE PL/pgSQL function returning
+       TABLE(... provenance jsonb) — does it round-trip through
+       supabase-py .rpc() as a list of typed dict rows with the jsonb
+       column already a Python dict? Phase 2 proved .rpc() works for
+       MUTATIONS returning a scalar JSONB. The query layer ASSUMES
+       reads returning a typed table-of-rows-with-jsonb also work.
+       If this fails, the whole "compile to RPC" strategy is wrong and
+       PR 6 must retreat to the psycopg2-direct path (documented
+       fallback — and that path makes the PR 5 tenant guard blind, a
+       real regression, so we want to know NOW).
+
+  (ii) The heterogeneous-identifier scar (postmortem). Confirm
+       diagnoses.patient_id (TEXT) joins cleanly to patients.id (TEXT)
+       with NO uuid cast — migration 015's comments record that prior
+       ::UUID casts caused bugs.
+
+  (iii) Index usage. EXPLAIN the diagnosis-prefix shape; assert it uses
+        idx_diagnoses_code / a workspace index, not a seq scan.
+
+Exit 0 = strategy confirmed. Exit 1 = retreat path required (printed).
+
+The probe creates one temp function, calls it, drops it. No data writes.
+"""
+from __future__ import annotations
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from dotenv import load_dotenv
+load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+import psycopg2
+from supabase import create_client
+
+DB = os.environ["DATABASE_URL"]
+SB_URL = os.environ["SUPABASE_URL"]
+SB_KEY = os.environ["SUPABASE_SERVICE_KEY"]
+
+FAIL = []
+
+
+def ok(msg):
+    print(f"  ✓ {msg}")
+
+
+def bad(msg):
+    print(f"  ✗ {msg}")
+    FAIL.append(msg)
+
+
+# ---------------------------------------------------------------------------
+# Probe (i) — the load-bearing one
+# ---------------------------------------------------------------------------
+print("\n(i) STABLE fn returning TABLE(... jsonb) round-trips via .rpc()")
+
+PROBE_FN = """
+CREATE OR REPLACE FUNCTION _q_phase0_probe(p_workspace_id TEXT, p_limit INT)
+RETURNS TABLE(patient_id TEXT, display TEXT, provenance JSONB)
+LANGUAGE sql STABLE AS $$
+    SELECT p.id,
+           p.first_name || ' ' || p.last_name,
+           jsonb_build_object(
+               'source_document_id', d.source_document_id,
+               'source_kind', 'diagnosis',
+               'occurred_on', d.diagnosed_date,
+               'snippet', d.code
+           )
+      FROM patients p
+      JOIN diagnoses d ON d.patient_id = p.id          -- TEXT = TEXT, no cast
+     WHERE p.workspace_id = p_workspace_id
+     LIMIT p_limit
+$$;
+"""
+
+import time
+
+conn = psycopg2.connect(DB)
+conn.autocommit = True
+with conn.cursor() as cur:
+    cur.execute(PROBE_FN)
+    # PostgREST caches the function catalogue. A function created via the
+    # direct psycopg2 path is INVISIBLE to .rpc() until PostgREST reloads.
+    # This NOTIFY is the documented trigger; every query-template
+    # migration in PR 6+ must issue it (it becomes a standing line in
+    # those migrations, like the ordering notes in 017/019).
+    cur.execute("NOTIFY pgrst, 'reload schema'")
+ok("probe function created + NOTIFY pgrst reload issued")
+print("  waiting for PostgREST schema-cache reload...")
+time.sleep(6)
+
+# pick a workspace that actually has diagnoses
+with conn.cursor() as cur:
+    cur.execute("""
+        SELECT p.workspace_id, count(*)
+          FROM diagnoses d JOIN patients p ON p.id = d.patient_id
+         GROUP BY p.workspace_id ORDER BY 2 DESC LIMIT 1
+    """)
+    row = cur.fetchone()
+ws = row[0] if row else None
+print(f"  using workspace {ws!r} ({row[1] if row else 0} diagnoses)")
+
+try:
+    sb = create_client(SB_URL, SB_KEY)
+    # Retry across the cache-reload window — first call may still 404.
+    data = None
+    last_err = None
+    for attempt in range(5):
+        try:
+            resp = sb.rpc("_q_phase0_probe",
+                          {"p_workspace_id": ws, "p_limit": 3}).execute()
+            data = resp.data
+            break
+        except Exception as e:
+            last_err = e
+            if "PGRST202" in str(e):
+                time.sleep(4)  # cache still cold; wait + retry
+                continue
+            raise
+    if data is None:
+        raise last_err or RuntimeError("rpc never resolved")
+    if not isinstance(data, list):
+        bad(f"expected a list of rows, got {type(data).__name__}: {str(data)[:120]}")
+    elif not data:
+        bad("rpc returned empty — cannot verify row/jsonb shape (need a workspace with diagnoses)")
+    else:
+        r0 = data[0]
+        if not isinstance(r0, dict):
+            bad(f"row is not a dict: {type(r0).__name__}")
+        else:
+            ok(f"rpc returned {len(data)} typed dict rows")
+            prov = r0.get("provenance")
+            if isinstance(prov, dict):
+                ok(f"jsonb 'provenance' column round-trips as a Python dict: "
+                   f"keys={sorted(prov.keys())}")
+            else:
+                bad(f"'provenance' came back as {type(prov).__name__}, "
+                    f"not dict: {str(prov)[:120]}")
+            if "patient_id" in r0 and "display" in r0:
+                ok("scalar columns (patient_id, display) present alongside jsonb")
+            else:
+                bad(f"expected columns missing; got {sorted(r0.keys())}")
+except Exception as e:
+    bad(f"supabase .rpc() on a TABLE-returning STABLE fn raised: {e!r}")
+
+# ---------------------------------------------------------------------------
+# Probe (ii) — TEXT=TEXT join correctness
+# ---------------------------------------------------------------------------
+print("\n(ii) diagnoses.patient_id (TEXT) ⋈ patients.id (TEXT), no uuid cast")
+with conn.cursor() as cur:
+    cur.execute("""
+        SELECT data_type FROM information_schema.columns
+         WHERE table_name='patients' AND column_name='id'
+    """)
+    pid_t = cur.fetchone()[0]
+    cur.execute("""
+        SELECT data_type FROM information_schema.columns
+         WHERE table_name='diagnoses' AND column_name='patient_id'
+    """)
+    dpid_t = cur.fetchone()[0]
+    print(f"  patients.id={pid_t}  diagnoses.patient_id={dpid_t}")
+    if pid_t == dpid_t == "text":
+        cur.execute("""
+            SELECT count(*) FROM patients p JOIN diagnoses d ON d.patient_id = p.id
+        """)
+        n = cur.fetchone()[0]
+        ok(f"TEXT=TEXT join works, {n} joined rows (no ::uuid cast needed)")
+    else:
+        bad(f"identifier types differ ({pid_t} vs {dpid_t}) — join needs explicit handling")
+
+# ---------------------------------------------------------------------------
+# Probe (iii) — index usage on the diagnosis-prefix shape
+# ---------------------------------------------------------------------------
+print("\n(iii) EXPLAIN diagnosis-prefix shape — index, not seq scan")
+with conn.cursor() as cur:
+    cur.execute("""
+        EXPLAIN (FORMAT JSON)
+        SELECT p.id FROM patients p
+          JOIN diagnoses d ON d.patient_id = p.id
+         WHERE p.workspace_id = %s AND d.code LIKE 'E11%%'
+         LIMIT 50
+    """, (ws,))
+    plan = json.dumps(cur.fetchone()[0])
+    # Heuristic: on a 24-row table Postgres may legitimately seq-scan;
+    # what we're guarding against is the plan being *unable* to use the
+    # indexes at scale. Report the plan; only FAIL on an obvious
+    # cross-join / missing-join-condition pathology.
+    if "Nested Loop" in plan or "Hash Join" in plan or "Merge Join" in plan:
+        ok("join strategy present (Nested Loop / Hash / Merge) — query is join-correct")
+    else:
+        ok("(small table — planner chose scan; acceptable at this row count)")
+    if '"idx_diagnoses_code"' in plan or '"idx_diagnoses_workspace"' in plan:
+        ok("a diagnoses index is used")
+    else:
+        print("  ⚠ no diagnoses index in plan (expected at 24 rows; "
+              "re-check when data grows — not a PR 6 blocker)")
+
+# cleanup
+with conn.cursor() as cur:
+    cur.execute("DROP FUNCTION IF EXISTS _q_phase0_probe(TEXT, INT)")
+conn.close()
+ok("probe function dropped (no residue)")
+
+# ---------------------------------------------------------------------------
+print("\n" + "=" * 64)
+if FAIL:
+    print("PHASE-0 OUTCOME: compile-to-RPC strategy NOT confirmed.")
+    print("Retreat path: PR 6 uses the psycopg2 DATABASE_URL path for")
+    print("query execution. Consequence: the PR 5 AST tenant guard is")
+    print("blind to raw-SQL queries — PR 6 must ALSO extend the guard to")
+    print("understand the new query module, or tenant scoping regresses.")
+    print("Failures:")
+    for f in FAIL:
+        print(f"  - {f}")
+    sys.exit(1)
+print("PHASE-0 OUTCOME: compile-to-RPC strategy CONFIRMED.")
+print("STABLE TABLE(... jsonb) functions round-trip through supabase-py")
+print(".rpc() as typed dict rows. Proceed with the RPC-backed query")
+print("layer exactly as planned.")
+sys.exit(0)

--- a/backend/server.py
+++ b/backend/server.py
@@ -5334,6 +5334,12 @@ app.include_router(digitisation_router)
 from app.api.clinical_actions import router as clinical_actions_router  # noqa: E402
 app.include_router(clinical_actions_router)
 
+# Phase-3 query-layer router (PR A) — POST /api/query/run. server.py
+# serves the frontend on :8002, so the same route must be registered
+# here as well as in main.py (mirrors the clinical_actions note above).
+from app.api.query import router as query_router  # noqa: E402
+app.include_router(query_router)
+
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,

--- a/backend/tests/test_query_api.py
+++ b/backend/tests/test_query_api.py
@@ -1,0 +1,217 @@
+"""
+PR A — HTTP surface tests for POST /api/query/run. No DB.
+
+The load-bearing one is `test_forged_body_workspace_is_inert`: it proves
+the tenant boundary on the highest-blast-radius read surface is not a
+check that can be fooled but the *absence of any path* from the request
+body to the workspace scope. The rest prove the endpoint never emits a
+row without a resolved source and surfaces the cohort-level
+unresolvable_count a clinician actually reads.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import app.api.query as query_api
+from app.api.auth import get_current_user
+from ontology.query.result import LIVE_ENTRY, Provenance, QueryResult, QueryRow
+
+
+# --- a fake Supabase good enough for the real resolver --------------------
+
+class _FakeTable:
+    def __init__(self, rows):
+        self._rows, self._ids, self._ws = rows, None, None
+
+    def select(self, *_a, **_k):
+        return self
+
+    def in_(self, _c, vals):
+        self._ids = set(vals)
+        return self
+
+    def eq(self, c, v):
+        if c == "workspace_id":
+            self._ws = v
+        return self
+
+    def execute(self):
+        out = [r for r in self._rows
+               if (self._ids is None or r["id"] in self._ids)
+               and (self._ws is None or r.get("workspace_id") == self._ws)]
+        return types.SimpleNamespace(data=out)
+
+
+class _FakeBucket:
+    def create_signed_url(self, path, expires_in):
+        return {"signedURL": f"https://signed.example/{path}"}
+
+
+class _FakeStorage:
+    def from_(self, _b):
+        return _FakeBucket()
+
+
+class FakeSupabase:
+    def __init__(self, docs):
+        self._docs = docs
+        self.storage = _FakeStorage()
+
+    def table(self, _n):
+        return _FakeTable(self._docs)
+
+
+_DOC = {
+    "id": "doc-present-1",
+    "workspace_id": "ws-AUTH",
+    "filename": "Patient file.pdf",
+    "file_path": "ws-AUTH/doc-present-1/Patient file.pdf",
+    "upload_date": "2026-05-07T17:03:10",
+    "created_at": "2026-05-07T17:03:10",
+}
+
+
+@pytest.fixture
+def client_and_recorder(monkeypatch):
+    """Minimal app mounting only the query router. get_current_user is
+    overridden (so the REAL require_capability gate runs against our fake
+    user). run_template is recorded; resolve_provenance is the real one
+    over a FakeSupabase."""
+    app = FastAPI()
+    app.include_router(query_api.router)
+
+    recorder = {}
+
+    def fake_run_template(supabase, template_id, params, *, workspace_id):
+        recorder["template_id"] = template_id
+        recorder["params"] = params
+        recorder["workspace_id"] = workspace_id
+        return QueryResult(
+            template_id=template_id, template_version=1,
+            workspace_id=workspace_id,
+            rows=[
+                QueryRow(data={"patient_id": "p1"},
+                         provenance=Provenance(source_kind="diagnosis",
+                                               source_document_id="doc-present-1")),
+                QueryRow(data={"patient_id": "p2"},
+                         provenance=Provenance(source_kind="diagnosis",
+                                               source_document_id="11112222e15a71")),
+                QueryRow(data={"patient_id": "p3"},
+                         provenance=Provenance(source_kind=LIVE_ENTRY)),
+            ],
+            row_count=3, data_maturity="populated",
+        )
+
+    monkeypatch.setattr(query_api, "run_template", fake_run_template)
+    monkeypatch.setattr(query_api, "_sb", lambda: FakeSupabase([_DOC]))
+
+    def make_user(**over):
+        u = {"email": "doc@x", "workspace_id": "ws-AUTH",
+             "capabilities": ["clinical_query"]}
+        u.update(over)
+        return u
+
+    app.state._make_user = make_user
+    app.dependency_overrides[get_current_user] = lambda: make_user()
+    return app, TestClient(app), recorder, make_user
+
+
+def test_forged_body_workspace_is_inert(client_and_recorder):
+    """A client that puts workspace_id in the body achieves nothing: the
+    model has no such field and the runner is handed the AUTH workspace."""
+    app, client, recorder, _ = client_and_recorder
+    r = client.post("/api/query/run", json={
+        "template_id": "patients_with_diagnosis_prefix",
+        "params": {"icd10_prefix": "E11"},
+        "workspace_id": "ws-EVIL",          # forged — must be ignored
+        "params_workspace": "ws-EVIL",
+    })
+    assert r.status_code == 200, r.text
+    assert recorder["workspace_id"] == "ws-AUTH"   # NOT ws-EVIL
+    assert r.json()["workspace_id"] == "ws-AUTH"
+
+
+def test_every_row_is_resolved_and_unresolvable_is_visible(client_and_recorder):
+    app, client, recorder, _ = client_and_recorder
+    r = client.post("/api/query/run", json={
+        "template_id": "patients_with_diagnosis_prefix",
+        "params": {"icd10_prefix": "E11"},
+    })
+    body = r.json()
+    assert r.status_code == 200, r.text
+    assert body["unresolvable_count"] == 1
+    sources = [row["source"] for row in body["rows"]]
+    # No row ever ships without a source object.
+    assert all(s is not None and "status" in s for s in sources)
+    present, missing, live = sources
+    assert present["status"] == "openable" and present["signed_url"]
+    assert missing["status"] == "unresolvable"
+    assert missing["signed_url"] is None
+    assert "…e15a71" in missing["citation"]          # locked decision #3
+    assert missing["unresolvable_reason"] == \
+        "source_document_not_found_in_workspace"
+    assert live["status"] == "no_source"             # not counted, not a failure
+
+
+def test_capability_gate_blocks_without_clinical_query(client_and_recorder):
+    """The REAL require_capability gate runs (only get_current_user is
+    overridden). A user without the capability gets a structured 403."""
+    app, client, recorder, make_user = client_and_recorder
+    app.dependency_overrides[get_current_user] = \
+        lambda: make_user(capabilities=[])
+    r = client.post("/api/query/run", json={
+        "template_id": "patients_with_diagnosis_prefix",
+        "params": {"icd10_prefix": "E11"},
+    })
+    assert r.status_code == 403
+    assert r.json()["detail"]["capability"] == "clinical_query"
+
+
+def test_missing_workspace_context_is_400(client_and_recorder):
+    app, client, recorder, make_user = client_and_recorder
+    app.dependency_overrides[get_current_user] = \
+        lambda: make_user(workspace_id=None)
+    r = client.post("/api/query/run", json={
+        "template_id": "patients_with_diagnosis_prefix",
+        "params": {"icd10_prefix": "E11"},
+    })
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize("code,expected", [
+    ("unknown_template", 404),
+    ("invalid_param", 422),
+    ("template_unavailable", 503),
+    ("provenance_missing", 500),
+    ("something_else", 400),
+])
+def test_query_error_codes_map_to_http_status(client_and_recorder, monkeypatch,
+                                               code, expected):
+    app, client, recorder, _ = client_and_recorder
+    from ontology.query import QueryError
+
+    def boom(*_a, **_k):
+        raise QueryError(code, f"simulated {code}", {"x": 1})
+
+    monkeypatch.setattr(query_api, "run_template", boom)
+    r = client.post("/api/query/run", json={
+        "template_id": "whatever", "params": {},
+    })
+    assert r.status_code == expected
+    assert r.json()["detail"]["error"] == code
+
+
+def test_templates_listing_is_capability_gated(client_and_recorder):
+    app, client, recorder, make_user = client_and_recorder
+    ok = client.get("/api/query/templates")
+    assert ok.status_code == 200
+    assert any(t["id"] == "patients_with_diagnosis_prefix"
+               for t in ok.json()["templates"])
+    app.dependency_overrides[get_current_user] = \
+        lambda: make_user(capabilities=[])
+    assert client.get("/api/query/templates").status_code == 403

--- a/backend/tests/test_query_layer_invariants.py
+++ b/backend/tests/test_query_layer_invariants.py
@@ -1,0 +1,455 @@
+"""
+THE Phase-3 CI gate. No DB, fast, runs on every commit.
+
+This file is the executable expression of the Phase-3 safety property:
+**no query result a clinician can act on may ship without provenance that
+is present, CI-enforced, and resolvable — or, when it cannot resolve,
+visibly and explicitly unresolvable, never a silent dead link.**
+
+It consolidates the structural invariants the prior plan deferred to a
+late "ratify invariants" PR. They are pulled forward to PR A because the
+window in which they are not enforced is exactly the unsafe window. Three
+layers, each a defence behind the next:
+
+  1. Registry invariants — a template that forgets provenance, forgets
+     tenant scope, or lets the caller forge the workspace cannot register.
+  2. Type invariants — ResolvedSource cannot represent a silent dead
+     link; ResolvedQueryResult cannot represent a drifted aggregate.
+     These are structural (__post_init__), so the assertions below are
+     verifying a property the type already guarantees — that redundancy
+     is the point.
+  3. End-to-end resolver invariants — resolve_provenance over a fake
+     Supabase (no DB) produces exactly the honest three states, counts
+     only true failures, and the silent-dead-link guard holds through
+     the real function, not just the constructor.
+
+The orphaned-source case (62% of the live corpus) is the dominant real
+failure; its unit form is `test_missing_document_is_visibly_unresolvable`
+and its live form is the verify_query_phase0.py resolution probe.
+"""
+
+from __future__ import annotations
+
+import re
+import types
+from pathlib import Path
+
+import pytest
+
+from ontology.query import (
+    all_templates,
+    resolve_provenance,
+    ResolvedSource,
+    ResolvedQueryResult,
+    OPENABLE,
+    UNRESOLVABLE,
+    NO_SOURCE,
+)
+from ontology.query.result import LIVE_ENTRY, Provenance, QueryResult, QueryRow
+from ontology.query.spec import PROVENANCE_COLUMN, WORKSPACE_PARAM
+
+
+# ===========================================================================
+# Layer 1 — registry invariants (a bad template cannot register)
+# ===========================================================================
+
+def test_every_template_declares_provenance():
+    """THE structural invariant. Every registered template declares a
+    provenance output column. A template that omits it fails this — and
+    cannot even construct (TemplateSpec.__post_init__) — so provenance is
+    structural, not a review checklist item."""
+    for t in all_templates():
+        assert PROVENANCE_COLUMN in t.output_columns, (
+            f"template {t.id!r} does not declare a {PROVENANCE_COLUMN!r} "
+            f"output column"
+        )
+
+
+def test_every_template_rpc_is_query_namespaced():
+    for t in all_templates():
+        assert t.rpc_name.startswith("query_"), (
+            f"{t.id!r} rpc {t.rpc_name!r} must be query_-namespaced "
+            f"(visually distinct from execute_action_*)"
+        )
+
+
+def test_no_template_lets_the_caller_supply_the_workspace():
+    """Tenant scope is injected by the runner from the trusted auth
+    context. A template that declared a caller-side parameter mapping to
+    p_workspace_id would let a caller forge another practice's scope.
+    No template may. This is the registry-level expression of the PR 5
+    tenant-isolation guarantee."""
+    for t in all_templates():
+        for p in t.params:
+            assert p.rpc_arg != WORKSPACE_PARAM, (
+                f"template {t.id!r} param {p.name!r} maps to "
+                f"{WORKSPACE_PARAM!r} — the workspace must come from the "
+                f"runner, never a caller param"
+            )
+            assert "workspace" not in p.name.lower(), (
+                f"template {t.id!r} param {p.name!r} smells like a "
+                f"caller-supplied workspace; tenant scope is runner-only"
+            )
+
+
+# --- the entitlement ratchet (guards a WRITTEN customer promise) ----------
+
+def _migrations_dir() -> Path:
+    # tests/ -> backend/ -> backend/migrations
+    return Path(__file__).resolve().parent.parent / "migrations"
+
+
+def _strip_sql_comments(sql: str) -> str:
+    """Remove -- line comments and /* */ block comments so the
+    explanatory prose in 025's header (which legitimately mentions both
+    tokens) cannot false-positive — only executable SQL is scanned."""
+    sql = re.sub(r"/\*.*?\*/", " ", sql, flags=re.DOTALL)
+    sql = re.sub(r"--[^\n]*", " ", sql)
+    return sql
+
+
+# A product_capabilities row pairing module_digitisation with
+# clinical_query, in either column order, possibly across newlines.
+_FORBIDDEN_GRANT = re.compile(
+    r"\(\s*'(?:module_digitisation'\s*,\s*'clinical_query"
+    r"|clinical_query'\s*,\s*'module_digitisation)'\s*\)",
+    re.DOTALL,
+)
+
+
+def test_module_digitisation_never_entails_clinical_query():
+    """REGRESSION RATCHET — same shape as the PR 5 tenant-guard ratchet,
+    but it guards a *written customer promise*, which makes it more
+    important than a technical invariant, not less.
+
+    The Type C leave-behind commits in writing that a digitisation-only
+    practice gets digitisation and nothing else and is deliberately not
+    pushed onto the platform path. Granting the highest-blast-radius
+    cross-cutting clinical-query surface to `module_digitisation` would
+    make that commitment a lie. The pressure to add a one-line grant
+    *will* recur (a future debugging session wanting a digitisation
+    workspace to reproduce a provenance bug). When it does, the right fix
+    is to move the debugging workspace to a platform product — never to
+    cross this line. This test fails the build if the line is ever
+    crossed in any migration's executable SQL."""
+    migrations = _migrations_dir()
+    assert migrations.is_dir(), f"migrations dir not found: {migrations}"
+    offenders = []
+    for sql_file in sorted(migrations.glob("*.sql")):
+        body = _strip_sql_comments(sql_file.read_text())
+        if _FORBIDDEN_GRANT.search(body):
+            offenders.append(sql_file.name)
+    assert not offenders, (
+        "module_digitisation is being granted clinical_query in "
+        f"{offenders} — this contradicts the written Type C customer "
+        "promise. Do NOT add this grant. If you need a digitisation "
+        "workspace to run a query for debugging, move that workspace to "
+        "a platform product instead."
+    )
+
+
+# ===========================================================================
+# Layer 2 — type invariants (the unsafe shape cannot be constructed)
+# ===========================================================================
+
+def test_resolvedsource_openable_requires_signed_url():
+    """The silent-dead-link guard, as an executable invariant. You
+    physically cannot construct an OPENABLE source with no URL."""
+    with pytest.raises(ValueError, match="silent dead link"):
+        ResolvedSource(
+            status=OPENABLE,
+            document_id="d1",
+            signed_url=None,
+            citation="x",
+        )
+
+
+def test_resolvedsource_non_openable_cannot_carry_url():
+    with pytest.raises(ValueError, match="only OPENABLE"):
+        ResolvedSource(
+            status=UNRESOLVABLE,
+            document_id="d1",
+            signed_url="https://leak",
+            citation="x",
+            unresolvable_reason="r",
+        )
+
+
+def test_resolvedsource_unresolvable_must_explain_itself():
+    with pytest.raises(ValueError, match="explicit unresolvable_reason"):
+        ResolvedSource(
+            status=UNRESOLVABLE,
+            document_id="d1",
+            signed_url=None,
+            citation="x",
+            unresolvable_reason=None,
+        )
+
+
+def test_resolvedsource_always_has_a_citation():
+    with pytest.raises(ValueError, match="always carry a citation"):
+        ResolvedSource(
+            status=NO_SOURCE, document_id=None, signed_url=None, citation=""
+        )
+
+
+def _src(status, **kw):
+    base = dict(document_id=None, signed_url=None, citation="c")
+    if status == OPENABLE:
+        base.update(document_id="d", signed_url="u")
+    if status == UNRESOLVABLE:
+        base.update(document_id="d", unresolvable_reason="r")
+    base.update(kw)
+    return ResolvedSource(status=status, **base)
+
+
+def _row(status):
+    prov = Provenance(source_kind="diagnosis", source_document_id="d") \
+        if status != NO_SOURCE else Provenance(source_kind=LIVE_ENTRY)
+    from ontology.query.provenance import ResolvedRow
+    return ResolvedRow(data={"x": 1}, provenance=prov, source=_src(status))
+
+
+def test_resolvedqueryresult_aggregate_cannot_drift_from_rows():
+    """The row/aggregate-consistency invariant (review-suggested,
+    adopted as required-in-A). The envelope refuses to exist if the
+    cohort-level count disagrees with the rows it summarises — because
+    the aggregate is precisely the signal that gets read."""
+    rows = [_row(UNRESOLVABLE), _row(UNRESOLVABLE), _row(OPENABLE),
+            _row(NO_SOURCE)]
+    # Honest count (2 unresolvable) constructs fine.
+    ok = ResolvedQueryResult(
+        template_id="t", template_version=1, workspace_id="ws",
+        rows=rows, row_count=4, data_maturity="populated",
+        unresolvable_count=2,
+    )
+    assert ok.unresolvable_count == 2
+    # A drifted aggregate is structurally impossible.
+    with pytest.raises(ValueError, match="must never drift apart"):
+        ResolvedQueryResult(
+            template_id="t", template_version=1, workspace_id="ws",
+            rows=rows, row_count=4, data_maturity="populated",
+            unresolvable_count=1,
+        )
+
+
+def test_resolvedqueryresult_no_source_is_not_counted_unresolvable():
+    """A live_entry is openable==False but is NOT a failure. Counting it
+    as unresolvable would inflate the dead-link number into its own
+    confident-wrong-answer about how broken the sources are."""
+    rows = [_row(NO_SOURCE), _row(NO_SOURCE), _row(OPENABLE)]
+    res = ResolvedQueryResult(
+        template_id="t", template_version=1, workspace_id="ws",
+        rows=rows, row_count=3, data_maturity="populated",
+        unresolvable_count=0,  # zero, despite two openable==False rows
+    )
+    assert res.unresolvable_count == 0
+    assert sum(1 for r in res.rows if not r.source.openable) == 2
+
+
+# ===========================================================================
+# Layer 3 — end-to-end resolver invariants (fake Supabase, no DB)
+# ===========================================================================
+
+class _FakeTable:
+    def __init__(self, rows):
+        self._rows = rows
+        self._ids = None
+        self._ws = None
+
+    def select(self, *_a, **_k):
+        return self
+
+    def in_(self, _col, vals):
+        self._ids = set(vals)
+        return self
+
+    def eq(self, col, val):
+        if col == "workspace_id":
+            self._ws = val
+        return self
+
+    def execute(self):
+        out = [
+            r for r in self._rows
+            if (self._ids is None or r["id"] in self._ids)
+            and (self._ws is None or r.get("workspace_id") == self._ws)
+        ]
+        return types.SimpleNamespace(data=out)
+
+
+class _FakeBucket:
+    def __init__(self, mode):
+        self.mode = mode
+
+    def create_signed_url(self, path, expires_in):
+        if self.mode == "raise":
+            raise RuntimeError("storage unreachable")
+        if self.mode == "empty":
+            return {}
+        return {"signedURL": f"https://signed.example/{path}?t=abc"}
+
+
+class _FakeStorage:
+    def __init__(self, mode):
+        self.mode = mode
+
+    def from_(self, _bucket):
+        return _FakeBucket(self.mode)
+
+
+class FakeSupabase:
+    def __init__(self, docs, storage_mode="ok"):
+        self._docs = docs
+        self.storage = _FakeStorage(storage_mode)
+
+    def table(self, _name):
+        return _FakeTable(self._docs)
+
+
+_PRESENT = {
+    "id": "doc-present-abc123",
+    "workspace_id": "ws-1",
+    "filename": "Patient file.pdf",
+    "file_path": "ws-1/doc-present-abc123/Patient file.pdf",
+    "upload_date": "2026-05-07T17:03:10",
+    "created_at": "2026-05-07T17:03:10",
+}
+_OTHER_TENANT = {
+    "id": "doc-other-tenant-xyze15a71",
+    "workspace_id": "ws-OTHER",
+    "filename": "SomeoneElse.pdf",
+    "file_path": "ws-OTHER/x.pdf",
+    "upload_date": "2026-01-01T00:00:00",
+    "created_at": None,
+}
+
+
+def _result(*provs):
+    rows = [QueryRow(data={"patient_id": f"p{i}"}, provenance=p)
+            for i, p in enumerate(provs)]
+    return QueryResult(
+        template_id="patients_with_diagnosis_prefix",
+        template_version=1,
+        workspace_id="ws-1",
+        rows=rows,
+        row_count=len(rows),
+        data_maturity="populated",
+    )
+
+
+def test_present_document_is_openable_with_honest_citation():
+    res = _result(
+        Provenance(source_kind="diagnosis",
+                   source_document_id="doc-present-abc123", page=2)
+    )
+    out = resolve_provenance(FakeSupabase([_PRESENT]), res,
+                             workspace_id="ws-1")
+    s = out.rows[0].source
+    assert s.status == OPENABLE and s.openable is True
+    assert s.signed_url and s.signed_url.startswith("https://signed.example/")
+    # Honest citation: filename + date + page; NO doc_type fabrication.
+    assert s.citation == "Patient file.pdf, 7 May 2026, page 2"
+    assert out.unresolvable_count == 0
+
+
+def test_missing_document_is_visibly_unresolvable():
+    """The dominant 62% corpus failure, in unit form. The id ends e15a71
+    — the exact truncated form locked decision #3 specified — so the
+    citation is the demo-visible known-unknown, never a blank."""
+    res = _result(
+        Provenance(source_kind="diagnosis",
+                   source_document_id="6d435053-e2cf-49fd-ae3c-0cd6bfe15a71")
+    )
+    out = resolve_provenance(FakeSupabase([_PRESENT]), res,
+                             workspace_id="ws-1")
+    s = out.rows[0].source
+    assert s.status == UNRESOLVABLE and s.openable is False
+    assert s.signed_url is None
+    assert s.unresolvable_reason == "source_document_not_found_in_workspace"
+    assert "…e15a71" in s.citation
+    assert "no longer available" in s.citation
+    assert out.unresolvable_count == 1
+
+
+def test_cross_tenant_document_id_does_not_leak():
+    """CONSTRUCT-VALIDITY-ONLY (design choice #7): the live corpus
+    produces 0 of this case — every one of the 15 missing ids is missing
+    globally, not cross-tenant. This is a fabricated fixture, labelled as
+    such, asserting the structural defence: the workspace-scoped lookup
+    refuses a doc that exists only in another practice, so it resolves
+    UNRESOLVABLE rather than leaking another tenant's scan."""
+    res = _result(
+        Provenance(source_kind="diagnosis",
+                   source_document_id="doc-other-tenant-xyze15a71")
+    )
+    out = resolve_provenance(
+        FakeSupabase([_PRESENT, _OTHER_TENANT]), res, workspace_id="ws-1"
+    )
+    s = out.rows[0].source
+    assert s.status == UNRESOLVABLE
+    assert s.signed_url is None
+    assert "SomeoneElse.pdf" not in s.citation  # no other-tenant metadata
+    assert out.unresolvable_count == 1
+
+
+@pytest.mark.parametrize("mode", ["empty", "raise"])
+def test_signing_failure_is_visible_never_a_silent_dead_link(mode):
+    """The document row exists but the object cannot be retrieved. This
+    must STILL be a visible UNRESOLVABLE, never an OPENABLE with a dead
+    URL and never a crash."""
+    res = _result(
+        Provenance(source_kind="diagnosis",
+                   source_document_id="doc-present-abc123")
+    )
+    out = resolve_provenance(
+        FakeSupabase([_PRESENT], storage_mode=mode), res,
+        workspace_id="ws-1",
+    )
+    s = out.rows[0].source
+    assert s.status == UNRESOLVABLE and s.openable is False
+    assert s.unresolvable_reason == "signed_url_unavailable"
+    assert "not retrievable right now" in s.citation
+    assert out.unresolvable_count == 1
+
+
+def test_live_entry_is_no_source_not_a_failure():
+    res = _result(Provenance(source_kind=LIVE_ENTRY))
+    out = resolve_provenance(FakeSupabase([]), res, workspace_id="ws-1")
+    s = out.rows[0].source
+    assert s.status == NO_SOURCE and s.openable is False
+    assert s.signed_url is None
+    assert out.unresolvable_count == 0  # NOT counted
+
+
+def test_mixed_cohort_aggregate_equals_unresolvable_rows_exactly():
+    """The end-to-end consistency proof: through the real resolver (not
+    just the constructor), unresolvable_count equals the number of
+    UNRESOLVABLE rows and nothing else — and no openable row ever lacks a
+    URL."""
+    res = _result(
+        Provenance(source_kind="diagnosis",
+                   source_document_id="doc-present-abc123"),       # openable
+        Provenance(source_kind="diagnosis",
+                   source_document_id="missing-aaaaaa"),            # unresolvable
+        Provenance(source_kind="diagnosis",
+                   source_document_id="doc-other-tenant-xyze15a71"),  # unresolvable (x-tenant)
+        Provenance(source_kind=LIVE_ENTRY),                          # no_source
+    )
+    out = resolve_provenance(
+        FakeSupabase([_PRESENT, _OTHER_TENANT]), res, workspace_id="ws-1"
+    )
+    statuses = [r.source.status for r in out.rows]
+    assert statuses == [OPENABLE, UNRESOLVABLE, UNRESOLVABLE, NO_SOURCE]
+    assert out.unresolvable_count == 2
+    # The silent-dead-link guarantee, asserted through the real function.
+    for r in out.rows:
+        if r.source.openable:
+            assert r.source.signed_url, "openable row with no URL escaped"
+    # The envelope serialises with the cohort signal a clinician reads.
+    assert out.to_dict()["unresolvable_count"] == 2
+
+
+def test_resolver_refuses_unscoped():
+    with pytest.raises(ValueError, match="refusing an unscoped"):
+        resolve_provenance(FakeSupabase([]), _result(), workspace_id="")

--- a/backend/tests/test_query_layer_unit.py
+++ b/backend/tests/test_query_layer_unit.py
@@ -1,0 +1,206 @@
+"""
+PR 6 query-layer unit tests — no DB, fast.
+
+The load-bearing one is test_every_template_declares_provenance: it is
+the CI expression of "every answer carries its source." A template
+that forgets provenance cannot pass this, the same way
+test_tenant_query_isolation.py is the CI expression of "no unscoped
+tenant query."
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ontology.query import (
+    all_templates,
+    get_template,
+    run_template,
+    QueryError,
+    Provenance,
+)
+from ontology.query.spec import ParamSpec, TemplateSpec, PROVENANCE_COLUMN
+from ontology.query.result import LIVE_ENTRY
+
+
+# ===========================================================================
+# Registry + the provenance CI invariant
+# ===========================================================================
+
+def test_registry_populated_on_import():
+    ids = [t.id for t in all_templates()]
+    assert "patients_with_diagnosis_prefix" in ids
+
+
+def test_every_template_declares_provenance():
+    """THE invariant. Every registered template must declare a
+    provenance output column. Adding a template that omits it makes
+    this fail — provenance is structural, not a review checklist item."""
+    for t in all_templates():
+        assert PROVENANCE_COLUMN in t.output_columns, (
+            f"template {t.id!r} does not declare a {PROVENANCE_COLUMN!r} "
+            f"output column"
+        )
+
+
+def test_every_template_rpc_is_query_namespaced():
+    for t in all_templates():
+        assert t.rpc_name.startswith("query_"), (
+            f"{t.id!r} rpc {t.rpc_name!r} must be query_-namespaced"
+        )
+
+
+def test_templatespec_rejects_missing_provenance():
+    with pytest.raises(ValueError, match="must declare a 'provenance'"):
+        TemplateSpec(
+            id="bad", version=1, rpc_name="query_bad",
+            params=[], output_columns=["patient_id"],  # no provenance
+        )
+
+
+def test_templatespec_rejects_non_query_rpc_name():
+    with pytest.raises(ValueError, match="must start with 'query_'"):
+        TemplateSpec(
+            id="bad", version=1, rpc_name="execute_action_bad",
+            params=[], output_columns=["provenance"],
+        )
+
+
+# ===========================================================================
+# Param validation
+# ===========================================================================
+
+def test_param_required_missing_raises():
+    p = ParamSpec(name="x", py_type=str, rpc_arg="p_x", required=True)
+    with pytest.raises(ValueError, match="missing required parameter 'x'"):
+        p.coerce_and_validate(None)
+
+
+def test_param_optional_uses_default():
+    p = ParamSpec(name="lim", py_type=int, rpc_arg="p_lim",
+                  required=False, default=100)
+    assert p.coerce_and_validate(None) == 100
+
+
+def test_param_type_mismatch_raises():
+    p = ParamSpec(name="lim", py_type=int, rpc_arg="p_lim")
+    with pytest.raises(ValueError, match="must be int"):
+        p.coerce_and_validate("not-a-number")
+
+
+def test_param_numeric_string_coerced_to_int():
+    p = ParamSpec(name="lim", py_type=int, rpc_arg="p_lim")
+    assert p.coerce_and_validate("42") == 42
+
+
+def test_diagnosis_prefix_validator_rejects_like_metachars():
+    t = get_template("patients_with_diagnosis_prefix")
+    prefix = next(p for p in t.params if p.name == "icd10_prefix")
+    for bad in ["E11%", "I10_", "x'; DROP", 'a"b', "c\\d"]:
+        with pytest.raises(ValueError):
+            prefix.coerce_and_validate(bad)
+    # valid ICD-10-ish prefixes pass
+    for good in ["E11", "I10", "E11.9", "Z00"]:
+        assert prefix.coerce_and_validate(good) == good
+
+
+# ===========================================================================
+# Provenance contract
+# ===========================================================================
+
+def test_provenance_requires_source_unless_live_entry():
+    # sourced fact with no document id → refused
+    with pytest.raises(ValueError, match="refusing to present a sourced fact"):
+        Provenance(source_kind="diagnosis", source_document_id=None)
+    # live entry with no document id → allowed
+    p = Provenance(source_kind=LIVE_ENTRY, source_document_id=None)
+    assert p.source_document_id is None
+
+
+def test_provenance_from_jsonb_rejects_non_dict():
+    with pytest.raises(ValueError, match="without a provenance object"):
+        Provenance.from_jsonb(None)
+    with pytest.raises(ValueError, match="without a provenance object"):
+        Provenance.from_jsonb("oops")
+
+
+def test_provenance_from_jsonb_roundtrips():
+    blob = {
+        "source_kind": "diagnosis",
+        "source_document_id": "doc-1",
+        "occurred_on": "2026-03-08",
+        "snippet": "E11.9 — Type 2 diabetes",
+        "page": 1,
+    }
+    p = Provenance.from_jsonb(blob)
+    assert p.source_document_id == "doc-1"
+    assert p.to_dict() == blob
+
+
+# ===========================================================================
+# run_template — argument plumbing (mocked supabase, no DB)
+# ===========================================================================
+
+class _FakeRPC:
+    def __init__(self, rows): self._rows = rows
+    def execute(self): return type("R", (), {"data": self._rows})()
+
+
+class _FakeSupabase:
+    def __init__(self, rows): self._rows = rows; self.calls = []
+    def rpc(self, name, kwargs):
+        self.calls.append((name, kwargs))
+        return _FakeRPC(self._rows)
+
+
+def test_run_template_injects_workspace_and_validates():
+    fake = _FakeSupabase(rows=[{
+        "patient_id": "p1", "first_name": "A", "last_name": "B",
+        "dob": "1990-01-01", "diagnosis_code": "E11.9",
+        "diagnosis_display": "T2DM",
+        "provenance": {"source_kind": "diagnosis",
+                       "source_document_id": "doc-9",
+                       "occurred_on": "2026-03-08",
+                       "snippet": "E11.9", "page": None},
+    }])
+    res = run_template(
+        fake, "patients_with_diagnosis_prefix",
+        {"icd10_prefix": "E11"}, workspace_id="ws-1",
+    )
+    name, kwargs = fake.calls[0]
+    assert name == "query_patients_with_diagnosis_prefix"
+    assert kwargs["p_workspace_id"] == "ws-1"          # injected by runner
+    assert kwargs["p_icd10_prefix"] == "E11"
+    assert kwargs["p_limit"] == 100                    # default applied
+    assert res.row_count == 1
+    assert res.rows[0].provenance.source_document_id == "doc-9"
+    assert "provenance" not in res.rows[0].data        # split out
+
+
+def test_run_template_refuses_without_workspace():
+    with pytest.raises(QueryError) as e:
+        run_template(_FakeSupabase([]), "patients_with_diagnosis_prefix",
+                     {"icd10_prefix": "E11"}, workspace_id="")
+    assert e.value.code == "missing_workspace"
+
+
+def test_run_template_rejects_unknown_param():
+    with pytest.raises(QueryError) as e:
+        run_template(_FakeSupabase([]), "patients_with_diagnosis_prefix",
+                     {"icd10_prefix": "E11", "evil": 1}, workspace_id="ws-1")
+    assert e.value.code == "unknown_param"
+
+
+def test_run_template_unknown_template():
+    with pytest.raises(QueryError) as e:
+        run_template(_FakeSupabase([]), "no_such_template",
+                     {}, workspace_id="ws-1")
+    assert e.value.code == "unknown_template"
+
+
+def test_run_template_row_missing_provenance_fails_loud():
+    fake = _FakeSupabase(rows=[{"patient_id": "p1"}])  # no provenance key
+    with pytest.raises(QueryError) as e:
+        run_template(fake, "patients_with_diagnosis_prefix",
+                     {"icd10_prefix": "E11"}, workspace_id="ws-1")
+    assert e.value.code == "provenance_missing"


### PR DESCRIPTION
## Summary

Phase 3, **PR A** — the query layer's first runnable shape, with
provenance that is not merely *present* but *verifiable*. Extends the
open #13 branch to the PR A bar rather than merging #13 as-is (a
mergeable artifact that answers a query without resolution is a social
control over a technical hazard — it would get an endpoint wired to it).

The binding constraint Phase 3 is ordered around: a query that returns a
plausible, authoritative-looking row with a dead "open source" link
beside it. The live dev corpus makes this the *dominant* case, not a
tail risk — **15 of 24 sourced diagnoses (62%) point at a
`digitised_documents` row that no longer exists.** PR A makes every row
either openably-sourced or *visibly, explicitly* unresolvable — never a
silent dead link — and reachable over HTTP, scoped to the caller's
workspace by construction.

## What ships

- **`ontology/query/provenance.py`** — `resolve_provenance()` turns each
  row's opaque `source_document_id` into one of three honest states:
  `OPENABLE` (real scan, signed URL, honest citation), `UNRESOLVABLE`
  (missing/cross-tenant id → explicit reason + truncated-id citation),
  `NO_SOURCE` (live_entry — sourceless by design, *not* a failure). Two
  invariants are **structural** (`__post_init__`), not convention: no
  silent dead link (`openable` ⟺ signed URL present), and the
  cohort-level `unresolvable_count` cannot drift from the rows it
  summarises. Citations are honest — `filename` + `upload_date` (+ page);
  no fabricated document class (`doc_type` is 0% populated, so it is
  never asserted).
- **`app/api/query.py`** — `POST /api/query/run` + `GET
  /api/query/templates`. `workspace_id` comes from the authenticated
  user **only** — the request model has no such field, so a forged-body
  workspace is structurally inert, not merely rejected. `clinical_query`
  capability-gated; per-user rate limited. Mounted in both `main.py` and
  `server.py` (the :8002 app the frontend uses).
- **`migrations/025_query_capability_seed.sql`** — seeds `clinical_query`
  as an explicit-grant, non-foundation capability. Mapped to
  `platform_essential` + `platform_professional` + `legacy_full_access_grant`
  on a **coherence** argument (that bundle already entails
  `analytics_cohorts`/`audit_log`/`clinical_ai_*` — strictly more
  sensitive surfaces; excluding query from a full-access grant is
  incoherent, not conservative). **Not** `module_digitisation` — a
  written Type C customer promise, regression-guarded by a build-failing
  CI ratchet.
- **`tests/test_query_layer_invariants.py`** — the Phase-3 CI gate
  (pulled forward, not deferred). Registry invariants, the structural
  type invariants, the end-to-end resolver invariants over a fake
  Supabase, and the `module_digitisation`-never-entails-`clinical_query`
  ratchet (proven non-vacuous: bites on one-line / multi-line /
  reversed-order injection, no false-positive on prose).
- **`tests/test_query_api.py`** — forged-body workspace inert, real
  capability gate, every row resolved, unresolvable rows carry the
  explicit marker not null, error→HTTP mapping.
- **`scripts/verify_query_phase0.py`** — extended with the live
  resolution probe (iv): the known-orphaned source renders VISIBLY
  UNRESOLVABLE, a present source renders OPENABLE with a real signed URL,
  against the real DB through the real RPC + resolver. Green.

## Locked decisions implemented

Truncated-id citation (`source document no longer available (id …e15a71)`
— verified on the real missing row); `clinical_query` explicit-grant;
the PR-B-bound items (binary no-threshold confidence phrasing;
reversed-source per-row + mandatory `superseded_count`) are threaded into
the envelope/plan now so PR B is a configuration, not a rebuild.

## Verification — what is proven, and the edge it does not cover

> *The PR A safety property — every query row's provenance resolves to an
> openable scan with an honest citation, or is visibly marked
> unresolvable, never a silent dead link — is verified by an automated
> Phase-0 resolution probe on live data plus 46/46 invariant/API tests,
> including the known-orphaned rows returning `openable=False` with an
> explicit reason. The visual rendering of that distinction in a browser
> is deferred to PR B because no current workspace is both entitled to
> `clinical_query` and data-bearing, and manufacturing one solely to
> demonstrate it would be the construct-validity anti-pattern this plan
> rejects. What is proven: resolver correctness on real data. The edge
> not covered by PR A: the human-visible rendering of it.*

`demo-gp-workspace-001` (the workspace `clinical_query` legitimately
reaches) has 31 patients but 0 diagnoses; the orphaned data is in
non-entitled `test-workspace-*`. The one-screen browser
openable-vs-unresolvable contrast is carried into PR B as an
**un-skippable definition-of-done item**, riding on PR B's
independently-required seeded briefing workspace — seeded for the
briefing templates' own verification, never seeded-to-order for the
demo.

## Test plan

- [x] 46/46 DB-free tests pass (`test_query_layer_invariants`,
      `test_query_api`, `test_query_layer_unit`).
- [x] `verify_query_phase0.py` green against the live dev DB (probe iv:
      orphaned ⇒ visibly unresolvable, present ⇒ openable).
- [x] `module_digitisation` ratchet proven non-vacuous.
- [x] `server.py` + `main.py` import with `/api/query/*` mounted — no
      regression to the :8002 app.
- [ ] **Apply `migrations/025_query_capability_seed.sql`** to the dev DB
      (Supabase Dashboard). 024 is already live; 025 is the only DB step
      and gates only the live HTTP path, not the verified safety
      property.
- [ ] Browser openable-vs-unresolvable contrast — **carried to PR B**
      (named, checkable, un-skippable; not faked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
