### PR TITLE
feat(query): PR C — thinnest NL mapping over the closed registry (ships DISABLED)

### DIFF
--- a/ONTOLOGY_PHASE3_PRC_PLAN.md
+++ b/ONTOLOGY_PHASE3_PRC_PLAN.md
@@ -1,0 +1,430 @@
+# Phase 3 — PR C Implementation Plan: Thinnest NL Mapping (ships DISABLED)
+
+> **Status:** plan APPROVED at review (same bar as PR A / PR B / the
+> executor plans). Grounded in fresh live-codebase probes run
+> 2026-05-16. PR A + PR B MERGED to main. **All four decisions CLOSED
+> (§5, LOCKED). Two required changes applied: (1) §7 earns split into
+> the proven output-domain constraint vs the unverified-at-merge
+> mapping-correctness — unsoftened, the §4 ledger not re-fused; (2) §7
+> deferred gains the shared rate-limit-bucket coupling as a named
+> flag-enablement-review consequence.** Cleared for implementation —
+> gate first, classifier around it.
+>
+> Supersedes nothing in `ONTOLOGY_PHASE3_QUERY_LAYER_PLAN.md` (umbrella
+> source of truth); this is the detailed PR C plan its "PR C" section
+> deferred.
+>
+> **Premise corrections this probe surfaced (verify before asserting):**
+> - Provider/library unnamed in the umbrella. Live codebase has exactly
+>   one completion-capable client pattern (OpenAI, lazy, inside function
+>   bodies). PR C reuses the *construction pattern*; provider
+>   *enablement* stays a deferred governance decision (§5 #1). The plan
+>   picks the gate *shape*, not the provider.
+> - The umbrella implies a generic enable flag. `config.py`'s actual
+>   convention is `os.getenv(NAME,"false").lower()=="true"` on a
+>   `Settings(BaseSettings)` field (`DEBUG`, `ENABLE_METRICS`); default-
+>   off is the merge default by construction (§1 probe 2).
+> - "No client constructed with flag unset" was stated as a goal, not a
+>   mechanism. Corrected: §2 specifies the construction-ordering + three
+>   complementary executable traps that make it a real CI gate.
+> - `backend/.env`, not `../.env` (carried PR B correction, re-confirmed).
+
+---
+
+## 1. Empirical findings (live codebase) — file:line per probe
+
+**Probe 1 — existing LLM client (REUSE, do not invent).** Three
+OpenAI-using sites, all constructing the client **lazily inside a
+function body, never at module top-level**:
+- `backend/app/services/semantic_search.py:48-59` — canonical pattern:
+  module-global `_openai_client=None`; `_client()` does `from openai
+  import OpenAI` + `api_key=os.getenv("OPENAI_API_KEY")` + `if not
+  api_key: raise RuntimeError(...)` + construct. **PR C copies this
+  shape**, adding the flag check *before* the import line.
+- `backend/api/icd10.py:108-118` — `from openai import OpenAI` in the
+  handler; `client.chat.completions.create(model="gpt-4o", ...,
+  temperature=0.3, max_tokens=200)` — the completion-call shape PR C's
+  classifier uses (plus `tools=`/`tool_choice=`).
+- `backend/server.py:4272,4290,…` — `import openai` inside handlers;
+  confirms the no-import-time-construction convention is universal.
+Env key: `OPENAI_API_KEY`, `config.py:42`. `import openai` is
+network-free at import (socket-trap verified). No `anthropic` outside
+`.venv`.
+
+**Probe 2 — flag/settings convention.** `config.py:13-92`. Booleans:
+`NAME: bool = os.getenv("NAME","false").lower()=="true"` (`DEBUG`
+`:24`, `ENABLE_METRICS` `:71`). Global `settings=Settings()` `:92`.
+Recommended: `NL_QUERY_LLM_ENABLED: bool =
+os.getenv("NL_QUERY_LLM_ENABLED","false").lower()=="true"`. The env var
+is absent from `backend/.env` and the whole tree — default-off is
+**structural**, no commit flips it; enabling requires a deliberate env
+edit.
+
+**Probe 3 — registry → tool schema (the constrained-enum proof).**
+`callable(p.validator) is True` for **all 12 params across all 7
+templates**. `ParamSpec.validator` (`spec.py:49`) is a `Callable` and
+**cannot** be serialised to a JSON tool schema — exactly the umbrella's
+design-choice-#4 premise, confirmed. The classifier exposes only
+`{id, description, params:[{name,type,required,default}]}` — the *exact
+projection `GET /api/query/templates` already builds* (`query.py:134-153`).
+Validators stay runner-side (`spec.py:51-66`, `runner.py:71-88`); the
+classifier structurally cannot re-implement validation. Subtlety:
+`validate_order_by`'s `("name","last_consultation")` enum lives in the
+validator body — NOT on the serialisable surface; the schema cannot
+express it; an out-of-enum value is caught by the runner
+(`invalid_param`→422). The plan does not reflect validator internals
+into the schema (that is the drift the umbrella forbids) — §6.
+
+**Probe 4 — auth/gate/endpoint shape (mirror `/run`).**
+`require_capability("clinical_query")` gates `/run` (`query.py:159`) &
+`/templates` (`:127`) via `auth.py:255-287` reading hydrated
+`current_user["capabilities"]`. `workspace_id` from
+`current_user.get("workspace_id")` ONLY (`query.py:167`); request model
+has no `workspace_id` (load-bearing). Rate limiter
+`_enforce_rate_limit` (`query.py:83-96`, 30/60s). Error map
+`_CODE_TO_STATUS` (`:102-111`). Lazy `_sb()` (`:57-69`). `/ask` is a
+near-mechanical mirror; the classifier output feeds `run_template`
+exactly as `/run` feeds the body — **no new data path**.
+
+**Probe 5 — mockability of the default-off gate (most important).**
+The structural arrangement that makes the safety property a real gate
+(not hope) is in §2; the three complementary executable traps
+(client-sentinel, socket.connect trap, `__import__` trap) are specified
+there.
+
+**Probe 6 — umbrella premises adapted.** Provider/flag unnamed →
+fixed empirically (gate shape, not provider). "No client with flag
+unset" goal → mechanism (§2). Validators-not-serialisable → confirmed,
+leaned on. `/run` reusable verbatim → confirmed. Phrasing-set size
+unspecified → surfaced as §5 #4, not silently picked.
+
+---
+
+## 2. The load-bearing safety property, scoped FIRST
+
+**Property:** with `NL_QUERY_LLM_ENABLED` unset (merge default), there is
+NO path that constructs an LLM client or attempts any outbound network
+call, and `POST /api/query/ask` hard-refuses (feature-gated) without
+sending the question text — *which itself may be PII (a patient name)* —
+anywhere. Enforced structurally (lazy+gated construction; refusal
+precedes construction) and proven by a NAMED executable CI invariant.
+
+**Why this is THE thing the merge stands on (unsoftened):** the NL
+question *is itself PII-bearing*. There is no scrubber and the plan does
+not pretend one (a reliable name-stripper is itself unsolved; claiming
+it is the Phase-2 fake-property anti-pattern). **The disabled-default IS
+the safety boundary** — flag off ⇒ text never leaves the process ⇒
+nothing to scrub. The merge is safe not because PII is cleaned but
+because no PII-bearing text reaches any LLM until an explicit operator
+governance act (§5 #1).
+
+**Structural arrangement (implementable):**
+1. `nl_query.py` module-global `_llm_client=None`; the provider import
+   lives *inside* `_client()` (house pattern, probe 1) — never module
+   scope.
+2. `classify_question(question, …)` line 1 is the flag gate; flag off ⇒
+   return `NLRefusal(reason="nl_disabled", answerable=<registry list>)`
+   **before** `_client()`, before any import, before any network.
+3. `_client()` re-checks flag + key, raises typed error if either
+   missing (mirrors `semantic_search._client():56-58`) — defence in
+   depth.
+4. `/ask` maps a `nl_disabled` refusal to a stable status + the
+   answerable list; never 500, never silent.
+
+**NAMED CI invariant (the gate), in `backend/tests/test_nl_query.py`:**
+- `test_nl_disabled_constructs_no_client_and_makes_no_network_call` —
+  flag off; install (a) `_client` sentinel that raises if called, (b)
+  `socket.socket.connect` trap raising on any connect, (c) `__import__`
+  trap raising if the provider module imports; call
+  `classify_question("show me Jane Doe's medications")` (deliberately
+  PII-bearing); assert the `nl_disabled` refusal with answerable list is
+  returned AND **all three traps never fired**. Same shape as PR A's
+  silent-dead-link guard / PR B's `additional_sources` inertness gate.
+- `test_ask_endpoint_hard_refuses_when_disabled` — through the real
+  router + real `require_capability` (only `get_current_user`
+  overridden, PR A's `test_query_api.py` harness), flag off: `/ask`
+  returns the feature-gated refusal + answerable list; `run_template`
+  never called (recorder); no `_sb()`/network.
+Both quoted verbatim in the PR description's verification statement, at
+equal weight to PR A's "46/46".
+
+---
+
+## 3. Deliverables, file-by-file
+
+### 3.1 `backend/app/services/nl_query.py` (new)
+Structural style of `semantic_search.py`. Module docstring states (in
+the umbrella's register): thinnest constrained classifier over the
+CLOSED enum; NL2SQL rejected; ships DISABLED; the question can itself be
+PII so disabled-default is the boundary not a scrubber; classifier never
+validates (runner does); no new data path.
+- `NLRefusal{reason,message,answerable:List[dict]}`,
+  `NLClassification{template_id,params,confidence_note}`. `answerable`
+  built from `all_templates()` so refusal *always* states what IS
+  answerable — "hard refusal + answerable list, never a guess" is
+  structural.
+- `build_tool_schema()` — pure, no LLM/network. One constrained tool per
+  template from `all_templates()`: `{name:t.id, description, parameters:
+  {properties:{p.name:{type:_json_type(p.py_type),description:…}},
+  required:[…]}}`. **Surfaces only the serialisable projection — never
+  `validator`.** Plus a synthetic `refuse` tool so the model can decline
+  in-band. The tool set IS the registry, regenerated each call —
+  structurally cannot drift.
+- `_client()` — lazy singleton, flag+key guarded, provider import
+  inside; provider call isolated to `_invoke(client,messages,tools)` so
+  the §5-deferred provider swap touches one function.
+- `classify_question(question,*,model=None)` — (1) flag gate → immediate
+  `NLRefusal(nl_disabled)`; (2) build schema; (3) `_client()` + one
+  constrained tool-call (`tool_choice` forcing selection from the closed
+  set, low temp, small max-tokens); (4) `refuse`/unknown-tool/no-tool/
+  low-confidence → `NLRefusal(out_of_set|low_confidence, answerable)`,
+  **never a guess**; (5) valid selection → `NLClassification` with
+  params passed **uninterpreted** (runner validates). Output domain =
+  `{registered id}×{params}` ∪ refusal. Never SQL, never free-form.
+
+### 3.2 `backend/app/api/query.py` — add `POST /api/query/ask`
+Additive only; PR A/B code untouched. `QueryAskRequest` has **only**
+`question: str (1..512)` — NO `workspace_id` (load-bearing, same comment
+as `QueryRunRequest`). Handler: (1) `require_capability("clinical_query")`
+(§5 #3); (2) `_enforce_rate_limit` (reuse existing bucket — an NL call
+costs LLM+query; 30/min appropriately conservative; noted, unchanged);
+(3) `workspace_id` from auth, 400 if absent (verbatim `/run`); (4)
+`cls=classify_question(body.question)`; `NLRefusal` → structured
+`{status:"refused",reason,message,answerable}` with stable code
+(`nl_disabled` recommended 403 `{"error":"nl_disabled"}` for
+consistency with `require_capability`'s 403 — §5 may adjust); (5)
+`NLClassification` → `run_template(_sb(),cls.template_id,cls.params,
+workspace_id=…)` then `resolve_provenance(_sb(),result,workspace_id=…)`
+— **the identical chokepoint `/run` uses**, same `try/except QueryError
+→ _CODE_TO_STATUS`. Response = `resolved.to_dict()` + an
+`interpreted_as:{template_id,params}` echo (honest: the answer carries
+how it was reached). No other path to data.
+
+### 3.3 `backend/tests/test_nl_query.py` (new) — DB-free, network-free
+- The default-off named gate (§2): the two named tests.
+- `test_tool_schema_is_exactly_the_registry` — tool names ==
+  `{t.id}`∪`{refuse}`; params == serialisable projection; **no
+  validator in the serialised schema**. Drift fails CI (PR B
+  registry-iterating-invariant discipline).
+- Mocked-LLM **wiring (NOT intelligence — labelled)**: fake client,
+  fixture-driven tool-call; golden set (§5 #4) → assert the
+  fixture-chosen selection is passed *unmodified* to a recorded
+  `run_template`, and the real `resolve_provenance` over the
+  `test_query_api.py` `FakeSupabase` produces the envelope. Docstring
+  states verbatim: proves wiring, NOT that the LLM picks correctly.
+- Refusal matrix: `refuse` / unknown tool / no tool / low confidence →
+  refusal with answerable list; `run_template` never called (recorder).
+- `test_ask_only_reaches_data_through_run_template` — recorders prove
+  `/ask` reaches data via exactly `run_template`+`resolve_provenance`;
+  forged-body workspace inert (mirrors
+  `test_forged_body_workspace_is_inert`).
+- Capability + tenant mirror: `/ask` without `clinical_query` → 403.
+
+### 3.4 `backend/scripts/nl_query_eval.py` (new) — opt-in, NEVER CI
+`load_dotenv("backend/.env")`. Refuses unless
+`NL_QUERY_LLM_ENABLED` true AND explicit
+`--i-have-authorised-a-provider` flag (two-step operator opt-in; cannot
+be CI-wired; cannot send PII without deliberate authorisation). Runs the
+golden + held-out paraphrase + adversarial sets through the *real*
+`classify_question`; prints an accuracy table. Header + final line state
+verbatim: accuracy is reported never gated; never run in CI; refuses
+with the flag off. Not imported by any test/registered.
+
+### 3.5 Honest size discussion
+Umbrella's ~810 is the right *order*; no single LoC total asserted
+(PR B's deliberate refusal of false precision). Drivers: `nl_query.py`
+genuinely thin (gate + schema-over-`all_templates()` + one tool-call +
+refusal map); bulk is docstring discipline + the provider-isolation
+seam. `/ask` ~one handler + model (mechanical mirror). `test_nl_query.py`
+is the **largest** file and the honest driver — the named default-off
+gate (3 traps) + registry anti-drift gate + no-new-path proof + refusal
+matrix + the (user-bounded, §5 #4) golden set. Size is set by the
+locked phrasing-set scope, measured at implementation, not projected.
+
+---
+
+## 4. Construct-validity / honesty ledger
+
+| Claim | Verified by | Label |
+|---|---|---|
+| Flag off ⇒ no client, no outbound call, `/ask` hard-refuses w/o sending text | the two named gate tests (DB/network-free, real fn/router) | **structural invariant — proven, load-bearing** |
+| Tool schema cannot drift from registry | `test_tool_schema_is_exactly_the_registry` | **structurally enforced, proven** |
+| Classifier constrained to closed enum (no SQL/free-form) | refusal matrix + schema gate | **proven by construction** |
+| NL adds no new data path | `test_ask_only_reaches_data_through_run_template` + forged-body-inert | **proven** |
+| Mocked tests prove *wiring* (tool-call→chokepoint→envelope) | mocked client | **WIRING ONLY — explicitly NOT accuracy** |
+| Classifier picks the right template for real phrasings | `nl_query_eval.py`, opt-in, never CI | **only verifiable with LLM enabled — prose, NEVER a gate; unverified at merge** |
+| PII never reaches an LLM at merge | the disabled-default boundary (no scrubber) | **boundary is the flag, NOT a scrubber — stated unsoftened** |
+
+Nothing verifiable only with the LLM enabled is presented as proven. No
+mock/fixture appears as accuracy evidence.
+
+---
+
+## 5. Decisions closed at review (LOCKED)
+
+All four resolved at plan review. Coding implements exactly these.
+
+1. **Provider — DEFERRED (governance), LOCKED.** Plan picks only the
+   gate *shape* (default-off structural for any provider). Does NOT pick
+   OpenAI/Anthropic/other and does NOT authorise enablement. **A
+   deliberate operator governance act is required before the LLM is ever
+   turned on; not required to merge (PR C merges disabled).**
+2. **Flag — LOCKED: `NL_QUERY_LLM_ENABLED` on `config.py` `Settings`**,
+   `os.getenv("NL_QUERY_LLM_ENABLED","false").lower()=="true"`, the
+   `DEBUG`/`ENABLE_METRICS` house pattern (discoverable; the test
+   monkeypatches `settings.NL_QUERY_LLM_ENABLED`).
+3. **`/ask` capability — LOCKED: reuse `clinical_query`.** Coherence:
+   `/ask` reaches *exactly* the same data through the same chokepoint;
+   a capability narrower than the data it exposes is incoherent (the
+   locked-decision-#4 logic). **Two required PR-body statements:** (a)
+   the coherence justification stated explicitly; (b) **the explicit,
+   load-bearing point that reusing `clinical_query` (rather than minting
+   a new capability) means PR A's `module_digitisation`-does-NOT-entail-
+   `clinical_query` Type-C ratchet
+   (`test_module_digitisation_never_entails_clinical_query`)
+   automatically covers `/ask` by construction — the written Type-C
+   customer promise is enforced on the NL surface for free, zero new
+   ratchet code, *because* of the coherent choice.** Coherent-choice-
+   pays-twice; show it in the record. (A distinct `clinical_query_nl`
+   was rejected: it would need a migration-025-style seed = scope
+   expansion AND a new ratchet to keep the Type-C promise — the reuse
+   inherits both for free.)
+4. **Phrasing-set scope — LOCKED with the adversarial modification.**
+   In-set: thin as recommended — **1 canonical + 1 paraphrase per
+   template** (14 in-set goldens). Adversarial set: **the load-bearing
+   half; explicitly NOT governed by "thinnest"** — its sizing principle
+   is *hazard-shape coverage*, not minimality. The in-set goldens verify
+   the safe direction (a known-phrasing miss still produces a
+   constrained, runner-validated, provenance-resolved answer); the
+   dangerous direction is out-of-set phrasings that *almost* match a
+   template with a clinically material difference and must hard-refuse —
+   misclassification there is the silent-wrong-answer this whole phase
+   guards against, and it is *invisible to every structural gate* (it
+   stays inside the output-domain envelope). The adversarial set MUST
+   therefore include, at minimum:
+   - a **near-miss pair**: two phrasings differing by a clinically
+     material term, one mapping to a template, one that must refuse;
+   - a **PII-bearing question naming a real patient** — asserting
+     flag-off constructs **no client at all** (not "politely refuses");
+   - a **plausible clinical question with no registered template** —
+     must refuse with the answerable list, **never approximate to the
+     nearest template**.
+   Generic gibberish is the easy case and proves little; the near-miss
+   is the case that silently converts and is where the adversarial set
+   earns its place.
+
+---
+
+## 6. Risks (Phase-3 honesty standard)
+
+- **NL balloon** — mitigated *structurally by scope, not hope*: the
+  model's entire callable surface is the registry-derived tool set;
+  refusal is default outside the closed enum. Residual vector: the
+  phrasing set growing — bounded by §5 #4 being a deliberate user call.
+- **The question carries PII; disabled-default is the boundary, NOT a
+  scrubber** — stated unsoftened in the plan, `nl_query.py` docstring,
+  test docstrings, PR prose (same words). Risk: a reviewer infers a
+  scrubber exists; mitigation is the repeated explicit statement (PR
+  A/B "checkable-but-not-checked" / "construct-validity-only"
+  discipline).
+- **Mocked tests prove wiring, not accuracy** — risk green CI misread
+  as "NL works"; mitigation: test docstrings + PR verification
+  statement state verbatim accuracy is unverified until enabled, never
+  gated (PR B xfail-with-asserted-reason shape).
+- **Tool-schema/registry drift** — structurally prevented (regenerated
+  from `all_templates()` each call; named equality gate; no validator
+  surfaced). Hand-edit fails CI.
+- **Validator internals invisible to schema (accepted-by-design)** —
+  `validate_order_by`'s enum is validator-body, not serialisable; the
+  runner catches out-of-enum (`invalid_param`→422); the classifier
+  deliberately does NOT re-implement validation (design choice #4: the
+  runner is the single validation authority). Accepted: surfacing
+  validator internals IS the forbidden drift.
+- **Refactor-defeats-the-gate** — a future move of the provider import
+  to module top-level, or `_client()` before the flag check, would
+  silently defeat default-off. Mitigation: the `__import__`-trap +
+  `_client`-sentinel in the named gate fail the build if
+  construction/import becomes reachable with the flag off — the gate
+  guards its own preconditions.
+
+---
+
+## 7. What PR C earns; explicitly deferred to PR D
+
+**Earns — TWO claims, deliberately UN-fused (required tightening; the
+PR-A/PR-B earns-section overclaim, third occurrence, same cure — the
+earns section must not re-fuse what the §4 ledger correctly separated):**
+
+  - **PROVEN at merge — the output-domain constraint.** The classifier's
+    output domain is *exactly* `{registered template id} × {params}` ∪
+    refusal. It structurally *cannot* emit SQL, free-form, or an
+    unregistered template — the model's only callable surface is the
+    registry-derived tool set, regenerated each call and asserted equal
+    to the registry by the drift gate; the refusal matrix proves
+    out-of-set/unknown-tool/low-confidence → refusal. This is load-
+    bearing and earned. It rides the **same
+    `run_template`+`resolve_provenance` chokepoint** as `/run` (proven
+    by the no-new-data-path recorder, not asserted), so NL answers
+    inherit PR A/B's verifiable-provenance contract because it is the
+    *same code path*. And — coherent-choice-pays-twice — because `/ask`
+    reuses `clinical_query`, PR A's Type-C ratchet covers the NL surface
+    *for free, by construction* (decision #3).
+  - **NOT verified at merge — mapping correctness.** Whether the
+    classifier picks the *right* enum member for a given real phrasing
+    is **entirely unverified at merge** and is exactly the accuracy the
+    §4 ledger brackets. "Constrained to the closed enum" must NOT be
+    read as "safe": the classifier can pick the *wrong registered
+    template*, confidently, and that wrong answer still passes the
+    runner, still gets provenance-resolved, and still looks
+    authoritative — **the misclassification failure is *inside* the
+    safety envelope of every structural gate this PR ships and is
+    therefore invisible to all of them.** It is knowable only via the
+    opt-in eval once a provider is authorised. In a regulator's or a
+    future-self's hands, "constrained to the closed enum" must mean
+    *output-domain-constrained*, never *mapping-correct* — the half that
+    is false (it may do the *wrong* registered thing) is precisely the
+    silent-wrong-answer this entire phase exists to prevent, and it is
+    named here, unsoftened, exactly as the ledger names it.
+
+**Ships disabled**, and that disabled-default is a *structural CI
+invariant* (named, executable, three traps), not a comment: flag unset
+⇒ no client, no outbound call, the (PII-bearing) question goes nowhere,
+`/ask` hard-refuses with the answerable list. The umbrella's reframed
+standard applied to NL: **the provenance-verifiable primitives are the
+brakes (shipped & proven in A/B); NL is the steering wheel — brakes
+first, steering wheel ships locked until an operator deliberately
+enables it.**
+
+**Residual, unsoftened:** with the flag off (the merge state) classifier
+*accuracy is entirely unverified* — mocked tests prove wiring only;
+correctness is knowable only via the opt-in eval once a provider is
+authorised (governance, deferred outside Phase 3 engineering). No PII
+scrubber; the day the flag is on, PII-in-the-question reaches the chosen
+provider — a deliberate operator act the code makes hard, not
+impossible. NL does not widen what is answerable (only the 7 registered
+templates, exactly as `/run`).
+
+**Deferred to PR D (NOT absorbed here):** standing-query materialisation
+(`StandingQuery`, `materialise_standing_queries()`, `briefing_items`,
+migration 027, worker tick); `POST /api/query/briefing/refresh` + `GET
+/api/query/briefing`; the Phase 3 close-out post-mortem; the MANDATORY
+named-not-built conversion-instrumentation scope note (PR D deliverable,
+recorded here only as *not in PR C* — and tracked in memory
+[[phase3-tracked-deferrals]]); enabling the LLM / provider authorisation
+(governance, §5 #1); POPIA query-access logging (Phase 5 — NL rides the
+existing `run_template` chokepoint so it inherits that future decorator
+slot for free, a positive consequence of "no new data path").
+
+**Named deferred consequence — the shared rate-limit bucket (required
+addition; name it at the cheap boundary, not in production).** `/ask`
+reuses `/run`'s existing in-process 30/60s bucket (§3.2). With the flag
+off this is inert (no `/ask` traffic). The day the flag is enabled this
+becomes a real coupling: `/ask` and `/run` *share* a budget, so a burst
+of one consumes the other's. This is NOT a merge blocker (flag-off makes
+it inert, same logic as everything else deferred here) but it is a named
+consequence the **flag-enablement governance review (§5 #1) must
+include**: "decide whether `/ask` needs its own bucket" — resolved at
+that boundary, not discovered in production. Same discipline as the
+`prescription_items` index and the conversion-instrumentation note:
+name the deferred consequence where it is still cheap to see. Recorded
+in memory [[phase3-tracked-deferrals]] alongside the others.

--- a/backend/app/api/query.py
+++ b/backend/app/api/query.py
@@ -197,3 +197,96 @@ async def run_query(
         supabase, result, workspace_id=workspace_id
     )
     return resolved.to_dict()
+
+
+class QueryAskRequest(BaseModel):
+    """PR C. Note the absence of `workspace_id` — same load-bearing
+    reason as QueryRunRequest: the only place a workspace can come from
+    is the authenticated user; neither the body nor the LLM can supply
+    it. `question` may itself be PII (a patient name); with the NL flag
+    off it goes nowhere (the disabled-default IS the boundary)."""
+
+    question: str = Field(..., min_length=1, max_length=512)
+
+
+@router.post("/ask")
+async def ask_query(
+    body: QueryAskRequest,
+    current_user: dict = Depends(require_capability("clinical_query")),
+):
+    """PR C — thinnest NL surface. SHIPS DISABLED. Maps the question to
+    ONE registered template via a classifier constrained to the closed
+    registry enum (never SQL/free-form), then runs it through the
+    IDENTICAL `run_template` + `resolve_provenance` chokepoint `/run`
+    uses — there is NO other path to data, so NL answers structurally
+    inherit the verifiable-provenance contract.
+
+    Capability: `clinical_query` (reused, NOT a new capability). This is
+    the coherent choice and it pays twice: PR A's
+    `module_digitisation`-does-NOT-entail-`clinical_query` Type-C ratchet
+    automatically covers this NL surface by construction — the written
+    Type-C customer promise is enforced here for free, zero new ratchet
+    code, *because* the capability was reused rather than minted.
+
+    With `NL_QUERY_LLM_ENABLED` off (merge default) `classify_question`
+    hard-refuses on line 1 — no client, no network, the question text
+    goes nowhere.
+    """
+    from app.services.nl_query import (
+        NLClassification,
+        NLRefusal,
+        classify_question,
+    )
+
+    _enforce_rate_limit(current_user.get("email") or "anonymous")
+
+    workspace_id = current_user.get("workspace_id")
+    if not workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No workspace context",
+        )
+
+    outcome = classify_question(body.question)
+
+    if isinstance(outcome, NLRefusal):
+        # Refusal (disabled / out-of-set / low-confidence) always carries
+        # the answerable list; never a 500, never a silent guess.
+        code = (status.HTTP_403_FORBIDDEN
+                if outcome.reason == "nl_disabled"
+                else status.HTTP_422_UNPROCESSABLE_CONTENT)
+        raise HTTPException(status_code=code, detail=outcome.to_dict())
+
+    # Successful classification: feed the SAME chokepoint /run uses.
+    # The classifier passed params uninterpreted; the runner validates.
+    assert isinstance(outcome, NLClassification)
+    supabase = _sb()
+    try:
+        result = run_template(
+            supabase,
+            outcome.template_id,
+            outcome.params or {},
+            workspace_id=workspace_id,
+        )
+    except QueryError as qe:
+        raise HTTPException(
+            status_code=_CODE_TO_STATUS.get(qe.code, _DEFAULT_ERROR_STATUS),
+            detail={
+                "error": qe.code,
+                "message": qe.message,
+                "context": qe.context,
+            },
+        )
+
+    resolved = resolve_provenance(
+        supabase, result, workspace_id=workspace_id
+    )
+    out = resolved.to_dict()
+    # Honest: the answer carries HOW the NL was mapped, so the caller
+    # can see the interpretation (and catch a misclassification — the
+    # failure mode no structural gate can see).
+    out["interpreted_as"] = {
+        "template_id": outcome.template_id,
+        "params": outcome.params,
+    }
+    return out

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -69,6 +69,17 @@ class Settings(BaseSettings):
     # Monitoring
     SENTRY_DSN: Optional[str] = os.getenv("SENTRY_DSN")
     ENABLE_METRICS: bool = os.getenv("ENABLE_METRICS", "true").lower() == "true"
+
+    # Phase 3 PR C — natural-language query layer. SHIPS DISABLED.
+    # Default-off is structural: the env var is absent from .env and no
+    # commit sets it, so this is False at merge. With it False there is
+    # NO path that constructs an LLM client or makes any outbound call,
+    # and POST /api/query/ask hard-refuses WITHOUT sending the question
+    # text (which can itself be PII — a patient name) anywhere. The
+    # disabled-default IS the PII safety boundary; there is no scrubber.
+    # Enabling requires a deliberate operator governance act (provider
+    # authorisation), never a code change.
+    NL_QUERY_LLM_ENABLED: bool = os.getenv("NL_QUERY_LLM_ENABLED", "false").lower() == "true"
     
     # Rate Limiting
     RATE_LIMIT_PER_MINUTE: int = int(os.getenv("RATE_LIMIT_PER_MINUTE", "60"))

--- a/backend/app/services/nl_query.py
+++ b/backend/app/services/nl_query.py
@@ -1,0 +1,332 @@
+"""
+nl_query — Phase 3 PR C. The thinnest possible natural-language mapping
+onto the CLOSED query-template registry. SHIPS DISABLED.
+
+WHAT THIS IS (and is not):
+  - It is a constrained intent classifier whose entire output domain is
+    {registered template id} × {typed params} ∪ refusal. The model's
+    only callable surface is a tool schema generated from
+    `all_templates()` every call, so it cannot drift from the registry,
+    cannot emit SQL, cannot free-form, cannot name an unregistered
+    template. NL2SQL is rejected outright (umbrella design choice #4).
+  - It adds NO new data path. A successful classification is handed to
+    the SAME `run_template` + `resolve_provenance` chokepoint `/run`
+    uses, so NL answers structurally inherit PR A/B's verifiable-
+    provenance + openable/no_source/unresolvable contract — there is no
+    other way for this module to reach data.
+  - It does NOT validate params. The runner (ParamSpec.coerce_and_
+    validate + run_template's unknown-param rejection) is the single
+    validation authority; surfacing validator internals into the tool
+    schema would be the exact registry-drift the design forbids.
+
+THE SAFETY PROPERTY (the one thing the merge stands on):
+  With `settings.NL_QUERY_LLM_ENABLED` False (the merge default — the
+  env var is absent and no commit sets it), there is NO path here that
+  constructs an LLM client or makes any outbound network call, and the
+  caller's question — which CAN ITSELF BE PII (a patient name in "show
+  me Jane Doe's medications") — goes NOWHERE. There is NO scrubber and
+  this module does not pretend one: a reliable name-stripper is itself
+  unsolved, and claiming it would be the Phase-2 fake-property anti-
+  pattern. The disabled-default IS the PII safety boundary — flag off ⇒
+  the text never leaves the process ⇒ nothing to scrub. Enabling is a
+  deliberate operator governance act (provider authorisation), never a
+  code change.
+
+  Structural enforcement: the provider import lives ONLY inside
+  `_client()`; `classify_question`'s FIRST action is the flag gate,
+  returning a hard refusal BEFORE `_client()`, before any import, before
+  any network. Proven un-mockably by the named CI gate in
+  tests/test_nl_query.py (three independent traps: a `_client` sentinel,
+  a `socket.connect` trap, an `__import__` trap — all must stay silent
+  with the flag off, on the real path, with a deliberately PII-bearing
+  input).
+
+WHAT IS *NOT* VERIFIED AT MERGE (unsoftened, same as the plan's §4/§7):
+  The output-domain constraint above is proven. Whether the classifier
+  picks the *right* registered template for a given real phrasing —
+  mapping correctness — is ENTIRELY UNVERIFIED at merge. A wrong
+  registered template is still runner-validated, still provenance-
+  resolved, still looks authoritative: that misclassification is INSIDE
+  the safety envelope of every structural gate and is invisible to all
+  of them. "Constrained to the closed enum" means output-domain-
+  constrained, NEVER mapping-correct. Accuracy is knowable only via the
+  opt-in eval once a provider is authorised; mocked tests prove WIRING,
+  not intelligence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# NOTE: NO provider import at module scope. `from openai import OpenAI`
+# lives only inside `_client()` (house pattern: semantic_search._client).
+# A future refactor moving it here would silently defeat default-off;
+# the __import__-trap in the named CI gate fails the build if it does.
+
+REFUSE_TOOL = "refuse"  # synthetic in-band decline so the model is
+                        # never forced to pick when it should not.
+
+_REASON_DISABLED = "nl_disabled"
+_REASON_OUT_OF_SET = "out_of_set"
+_REASON_LOW_CONFIDENCE = "low_confidence"
+
+_llm_client = None  # lazy singleton; constructed ONLY when enabled
+
+
+@dataclass(frozen=True)
+class NLRefusal:
+    """A hard refusal. ALWAYS carries the answerable list — "refuse +
+    what IS answerable, never a guess" is structural, not optional."""
+
+    reason: str            # nl_disabled | out_of_set | low_confidence
+    message: str
+    answerable: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": "refused",
+            "reason": self.reason,
+            "message": self.message,
+            "answerable": self.answerable,
+        }
+
+
+@dataclass(frozen=True)
+class NLClassification:
+    """A successful mapping to ONE registered template + raw params.
+    Params are passed through UNINTERPRETED — the runner validates."""
+
+    template_id: str
+    params: Dict[str, Any]
+    confidence_note: Optional[str] = None
+
+
+def _json_type(py_type: type) -> str:
+    return {int: "integer", float: "number", bool: "boolean",
+            str: "string"}.get(py_type, "string")
+
+
+def _answerable() -> List[Dict[str, Any]]:
+    """The registry projection — IDENTICAL to what GET
+    /api/query/templates exposes. Built from all_templates() so it
+    cannot drift; never surfaces `validator` (a callable, unserialisable
+    — confirmed for all 12 params across all 7 templates)."""
+    from ontology.query import all_templates
+
+    out: List[Dict[str, Any]] = []
+    for t in all_templates():
+        out.append({
+            "id": t.id,
+            "description": t.description,
+            "params": [
+                {
+                    "name": p.name,
+                    "type": _json_type(p.py_type),
+                    "required": p.required,
+                    "default": p.default,
+                }
+                for p in t.params
+            ],
+        })
+    return out
+
+
+def build_tool_schema() -> List[Dict[str, Any]]:
+    """One constrained tool per registered template + the synthetic
+    `refuse`. The tool set IS the registry, regenerated each call — it
+    structurally cannot list an unregistered template nor omit a
+    registered one, and exposes ONLY the serialisable projection (never
+    a validator). This is the anti-drift mechanism; the
+    tool-schema-is-exactly-the-registry CI gate asserts it."""
+    tools: List[Dict[str, Any]] = []
+    for t in _answerable():
+        props: Dict[str, Any] = {}
+        required: List[str] = []
+        for p in t["params"]:
+            props[p["name"]] = {
+                "type": p["type"],
+                "description": (
+                    f"{p['name']} "
+                    + ("(required)" if p["required"]
+                       else f"(optional, default {p['default']!r})")
+                ),
+            }
+            if p["required"]:
+                required.append(p["name"])
+        tools.append({
+            "type": "function",
+            "function": {
+                "name": t["id"],
+                "description": t["description"],
+                "parameters": {
+                    "type": "object",
+                    "properties": props,
+                    "required": required,
+                    "additionalProperties": False,
+                },
+            },
+        })
+    tools.append({
+        "type": "function",
+        "function": {
+            "name": REFUSE_TOOL,
+            "description": (
+                "Decline. Use this when the question does not clearly "
+                "map to exactly one of the templates above, or is "
+                "ambiguous, or asks for something not registered. "
+                "Refusing is correct and expected — never approximate "
+                "to the nearest template."
+            ),
+            "parameters": {"type": "object", "properties": {},
+                           "additionalProperties": False},
+        },
+    })
+    return tools
+
+
+def _flag_enabled() -> bool:
+    # Imported here (not module scope) so the flag is read live and the
+    # test can monkeypatch settings.NL_QUERY_LLM_ENABLED.
+    from app.core.config import settings
+    return bool(getattr(settings, "NL_QUERY_LLM_ENABLED", False))
+
+
+def _client():
+    """Lazy singleton. Mirrors semantic_search._client() EXACTLY, with
+    the flag re-check FIRST (defence in depth: even a direct call
+    refuses with the flag off — the provider import is never reached).
+    `from openai import OpenAI` is inside this function, never module
+    scope."""
+    global _llm_client
+    if not _flag_enabled():
+        raise RuntimeError(
+            "nl_query._client() called with NL_QUERY_LLM_ENABLED off — "
+            "refusing to construct an LLM client"
+        )
+    if _llm_client is None:
+        from openai import OpenAI  # provider import — gated, lazy
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY missing — cannot run NL classification"
+            )
+        _llm_client = OpenAI(api_key=api_key)
+    return _llm_client
+
+
+def _invoke(client, messages: List[Dict[str, Any]],
+            tools: List[Dict[str, Any]], model: str) -> Any:
+    """The ONLY provider-specific call shape. Isolated so the
+    §5-deferred provider swap touches one function, not the classifier
+    logic. `tool_choice="required"` forces selection from the closed
+    set (the model must pick a registered template or `refuse` — it
+    cannot free-form). temperature=0 for determinism; small max_tokens
+    (we only need a tool call, never prose)."""
+    return client.chat.completions.create(
+        model=model,
+        messages=messages,
+        tools=tools,
+        tool_choice="required",
+        temperature=0,
+        max_tokens=256,
+    )
+
+
+_SYSTEM = (
+    "You map a clinician's question to EXACTLY ONE of the provided "
+    "tools (each is a registered query template) and its typed "
+    "parameters, or call `refuse`. You MUST call a tool. You may not "
+    "answer in prose, write SQL, or invent a template. If the question "
+    "does not clearly and unambiguously map to one template — including "
+    "near-misses that differ from a template by a clinically material "
+    "term — call `refuse`. Refusing is correct; approximating to the "
+    "nearest template is a serious error."
+)
+
+
+def classify_question(
+    question: str,
+    *,
+    model: Optional[str] = None,
+) -> NLRefusal | NLClassification:
+    """Map a question to a registered template, or refuse.
+
+    LINE-1 SAFETY GATE: the flag check is the first thing this function
+    does. With the flag off it returns a hard refusal BEFORE `_client()`,
+    before any provider import, before any network — so the (possibly
+    PII-bearing) question never leaves the process. Everything below the
+    gate is unreachable when disabled.
+    """
+    # ── THE GATE (must remain the first executable statement) ──────────
+    if not _flag_enabled():
+        return NLRefusal(
+            reason=_REASON_DISABLED,
+            message=(
+                "Natural-language queries are disabled. No text was sent "
+                "anywhere. Use one of the answerable query shapes "
+                "directly via /api/query/run."
+            ),
+            answerable=_answerable(),
+        )
+
+    # ── Below here only runs when an operator has deliberately enabled
+    #    the LLM (governance act). ───────────────────────────────────────
+    tools = build_tool_schema()
+    registered_ids = {t["function"]["name"] for t in tools}
+    client = _client()
+    resp = _invoke(
+        client,
+        messages=[
+            {"role": "system", "content": _SYSTEM},
+            {"role": "user", "content": question},
+        ],
+        tools=tools,
+        model=model or os.getenv("NL_QUERY_MODEL", "gpt-4o-mini"),
+    )
+
+    # Parse the tool call defensively — anything unexpected is a REFUSAL,
+    # never a guess.
+    try:
+        choice = resp.choices[0]
+        tool_calls = getattr(choice.message, "tool_calls", None) or []
+    except (AttributeError, IndexError, TypeError):
+        tool_calls = []
+
+    if not tool_calls:
+        return NLRefusal(
+            _REASON_LOW_CONFIDENCE,
+            "Could not map the question to a query shape.",
+            _answerable(),
+        )
+
+    call = tool_calls[0]
+    name = getattr(getattr(call, "function", None), "name", None)
+
+    if name == REFUSE_TOOL or name not in registered_ids:
+        # Includes: explicit refuse, an unknown/hallucinated tool name,
+        # or REFUSE_TOOL. Never executed; always the answerable list.
+        return NLRefusal(
+            _REASON_OUT_OF_SET,
+            "The question does not map to a registered query shape.",
+            _answerable(),
+        )
+
+    raw_args = getattr(getattr(call, "function", None), "arguments", "") or "{}"
+    try:
+        params = json.loads(raw_args)
+        if not isinstance(params, dict):
+            raise ValueError("arguments not an object")
+    except (json.JSONDecodeError, ValueError):
+        return NLRefusal(
+            _REASON_LOW_CONFIDENCE,
+            "The mapped parameters were not well-formed.",
+            _answerable(),
+        )
+
+    # Pass through UNINTERPRETED. The runner validates every param
+    # (ParamSpec) and rejects unknown ones; this module deliberately
+    # does not re-implement validation.
+    return NLClassification(template_id=name, params=params)

--- a/backend/scripts/nl_query_eval.py
+++ b/backend/scripts/nl_query_eval.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+nl_query_eval.py — OPT-IN real-LLM accuracy eval for the PR C NL layer.
+
+ACCURACY IS REPORTED, NEVER GATED. This script is NEVER run in CI. With
+`NL_QUERY_LLM_ENABLED` off it refuses. It is the ONLY thing that can
+verify classifier *mapping correctness* — which is, by design,
+UNVERIFIED at merge (the mocked unit tests prove WIRING only, not
+intelligence). Running it sends real (potentially PII-bearing) phrasings
+to whatever provider an operator has authorised, so it requires a
+deliberate TWO-STEP opt-in: the flag must be on AND
+`--i-have-authorised-a-provider` must be passed. It cannot be wired into
+CI accidentally and cannot send anything without an operator's explicit
+act.
+
+It is not imported by any test, nor by registered.py / __init__.py.
+
+Usage (operator, after authorising a provider — a governance act):
+  cd backend && NL_QUERY_LLM_ENABLED=true PYTHONPATH=. \
+    .venv/bin/python scripts/nl_query_eval.py --i-have-authorised-a-provider
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+# ── In-set golden phrasings (Decision #4: thin — 1 canonical + 1
+# paraphrase per registered template). The expected template is asserted;
+# params are spot-checked where unambiguous. ──────────────────────────────
+GOLDEN = [
+    # patients_with_diagnosis_prefix
+    ("which patients have an ICD-10 diagnosis starting with E11",
+     "patients_with_diagnosis_prefix"),
+    ("show me the type-2 diabetes cohort by code prefix E11",
+     "patients_with_diagnosis_prefix"),
+    # patients_not_seen_since
+    ("which patients have not been seen in the last 180 days",
+     "patients_not_seen_since"),
+    ("list patients overdue for a visit — nothing in ~6 months",
+     "patients_not_seen_since"),
+    # patient_active_medications
+    ("what is patient p1 currently on", "patient_active_medications"),
+    ("show p1's active medication list", "patient_active_medications"),
+    # patient_recent_consultations
+    ("show p1's last 5 consultations", "patient_recent_consultations"),
+    ("recent visits for patient p1", "patient_recent_consultations"),
+    # patients_with_abnormal_recent_vitals
+    ("who had a high blood pressure reading recently",
+     "patients_with_abnormal_recent_vitals"),
+    ("patients with abnormal BP in the last 90 days",
+     "patients_with_abnormal_recent_vitals"),
+    # patient_open_documents
+    ("which documents are still waiting on me",
+     "patient_open_documents"),
+    ("show open / not-yet-finalised documents", "patient_open_documents"),
+    # patients_with_lab_threshold
+    ("who has an HbA1c result over 8", "patients_with_lab_threshold"),
+    ("patients with a lab result above a threshold for HBA1C",
+     "patients_with_lab_threshold"),
+]
+
+# ── Adversarial set (Decision #4: the LOAD-BEARING half — NOT governed
+# by "thinnest"; sizing principle is HAZARD-SHAPE COVERAGE. Each MUST
+# refuse — the silent-wrong-answer this whole phase guards against is an
+# almost-match that converts instead of refusing). ─────────────────────────
+ADVERSARIAL = [
+    # near-miss: differs from patients_not_seen_since by a clinically
+    # material term ("should not see again" ≠ "not seen since").
+    "which patients should I not see again",
+    # plausible clinical question with NO registered template.
+    "what is the average waiting time in my practice this week",
+    # plausible-but-unregistered shape near a real one.
+    "delete patient p1's diabetes diagnosis",
+    # PII-bearing free-text that is not a registered shape — must refuse,
+    # never approximate to a template.
+    "is Thabo Mokoena overdue for his diabetic foot screening",
+]
+
+
+def _refuse(msg: str) -> int:
+    print(f"REFUSED: {msg}")
+    print("This script is opt-in, never CI; with the flag off it refuses; "
+          "accuracy is reported, never gated.")
+    return 2
+
+
+def main() -> int:
+    if "--i-have-authorised-a-provider" not in sys.argv:
+        return _refuse("missing --i-have-authorised-a-provider "
+                       "(deliberate two-step opt-in; a provider "
+                       "authorisation is a governance act)")
+    from app.core.config import settings
+    if not getattr(settings, "NL_QUERY_LLM_ENABLED", False):
+        return _refuse("NL_QUERY_LLM_ENABLED is off")
+
+    from app.services.nl_query import (
+        NLClassification, NLRefusal, classify_question,
+    )
+
+    print("=" * 70)
+    print("NL classifier accuracy eval — REPORTED, NEVER GATED, NEVER CI.")
+    print("Sends real (possibly PII-bearing) phrasings to the authorised "
+          "provider.")
+    print("=" * 70)
+
+    in_ok = 0
+    print("\n-- in-set goldens (1 canonical + 1 paraphrase / template) --")
+    for phrasing, expected in GOLDEN:
+        out = classify_question(phrasing)
+        got = (out.template_id if isinstance(out, NLClassification)
+               else f"REFUSED({out.reason})")
+        hit = isinstance(out, NLClassification) and out.template_id == expected
+        in_ok += 1 if hit else 0
+        print(f"  [{'OK ' if hit else 'MISS'}] {phrasing!r}\n"
+              f"        expected={expected} got={got}")
+
+    adv_ok = 0
+    print("\n-- adversarial (MUST refuse — hazard-shape coverage) --")
+    for phrasing in ADVERSARIAL:
+        out = classify_question(phrasing)
+        refused = isinstance(out, NLRefusal)
+        adv_ok += 1 if refused else 0
+        got = (f"REFUSED({out.reason})" if refused
+               else f"!! MAPPED to {out.template_id} (HAZARD: silent "
+                    f"conversion)")
+        print(f"  [{'OK ' if refused else 'FAIL'}] {phrasing!r}\n"
+              f"        {got}")
+
+    print("\n" + "=" * 70)
+    print(f"in-set mapping accuracy : {in_ok}/{len(GOLDEN)}")
+    print(f"adversarial refusal rate: {adv_ok}/{len(ADVERSARIAL)}")
+    print("REPORTED, NOT GATED. A low number here is a finding for "
+          "governance, not a CI failure — accuracy is unverified at "
+          "merge by design; this is the only thing that can verify it.")
+    print("=" * 70)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_nl_query.py
+++ b/backend/tests/test_nl_query.py
@@ -1,0 +1,452 @@
+"""
+PR C — NL mapping tests. DB-free, network-free, every commit.
+
+THE load-bearing gate is `test_nl_disabled_constructs_no_client_and_
+makes_no_network_call`: it is PR C's silent-dead-link / inertness
+equivalent — the one property the entire merge stands on, proven
+un-mockably on the REAL path with the flag off, asserting silence at
+three independent layers (client construction, outbound socket, provider
+import). The rest proves the output-domain constraint (NOT mapping
+correctness — that is unverified at merge by design) and that NL adds no
+new data path.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import socket
+import types
+
+import pytest
+
+import app.services.nl_query as nlq
+
+
+# ===========================================================================
+# THE NAMED DEFAULT-OFF GATE (build first, prove un-mockable, then the rest)
+# ===========================================================================
+
+def test_default_is_structurally_off():
+    """The merge default: the env var is absent and no commit sets it,
+    so the real setting is False without any monkeypatching."""
+    from app.core.config import settings
+    assert settings.NL_QUERY_LLM_ENABLED is False
+
+
+def test_nl_disabled_constructs_no_client_and_makes_no_network_call(monkeypatch):
+    """Flag off, REAL `classify_question`, deliberately PII-bearing
+    input. Three independent traps — a `_client` sentinel, a
+    `socket.socket.connect` trap, an `__import__` trap on the provider
+    module — must ALL stay silent. This is un-mockable: the refusal
+    happens before `_client()`, before any import, before any network,
+    so none of the three can fire if the gate holds. (Three layers, not
+    one, because the regression is a future refactor moving the import
+    to module scope or calling `_client()` before the gate — a single
+    trap at the wrong layer would miss it.)"""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", False)
+
+    fired = {"client": False, "socket": False, "import": False}
+
+    def _sentinel_client(*a, **k):
+        fired["client"] = True
+        raise AssertionError("_client() reached with flag off")
+    monkeypatch.setattr(nlq, "_client", _sentinel_client)
+
+    real_connect = socket.socket.connect
+
+    def _trap_connect(self, *a, **k):
+        fired["socket"] = True
+        raise AssertionError("outbound socket.connect attempted with flag off")
+    monkeypatch.setattr(socket.socket, "connect", _trap_connect)
+
+    real_import = builtins.__import__
+
+    def _trap_import(name, *a, **k):
+        if name == "openai" or name.startswith("openai."):
+            fired["import"] = True
+            raise AssertionError("provider module imported with flag off")
+        return real_import(name, *a, **k)
+    monkeypatch.setattr(builtins, "__import__", _trap_import)
+
+    # Deliberately PII-bearing: a real patient name in the question.
+    result = nlq.classify_question("show me Jane Doe's recent consultations")
+
+    monkeypatch.setattr(builtins, "__import__", real_import)
+    monkeypatch.setattr(socket.socket, "connect", real_connect)
+
+    assert isinstance(result, nlq.NLRefusal)
+    assert result.reason == "nl_disabled"
+    assert result.answerable, "refusal must still carry the answerable list"
+    # The whole point: nothing fired.
+    assert fired == {"client": False, "socket": False, "import": False}
+
+
+def test_traps_are_non_vacuous_each_fires_with_flag_ON(monkeypatch):
+    """The discriminating check: a gate proven only by SILENCE is not
+    proven — the flag-off green could mean "boundary held" OR "the path
+    that would trip the traps was never reached" (the
+    superseded_count=0-for-the-wrong-reason / ratchet-must-bite
+    discipline). So with the flag ON, each trap MUST fire on the thing
+    it guards. Three independent flag-on invocations, one trap armed
+    each (armed together they pre-empt each other — the `_client`
+    sentinel would fire before the import trap, etc.). If any of these
+    does NOT fire, the corresponding flag-off silence is worthless.
+    Shipped (not a one-time local check) so the non-vacuity is a
+    permanent CI property, exactly like PR B's ratchet."""
+    from app.core.config import settings
+
+    # (a) `_client` sentinel — proves the construction-layer trap bites.
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", True)
+    fired_a = {"v": False}
+
+    def _sentinel(*a, **k):
+        fired_a["v"] = True
+        raise AssertionError("_client reached")
+    monkeypatch.setattr(nlq, "_client", _sentinel)
+    try:
+        nlq.classify_question("anything")
+    except BaseException:  # noqa: BLE001 — we only care that it fired
+        pass
+    assert fired_a["v"], "_client sentinel did NOT fire flag-on — vacuous"
+    monkeypatch.undo()
+
+    # (b) `__import__` trap — proves the provider-import-layer trap bites.
+    #     No `_client` monkeypatch, so the REAL _client() runs and
+    #     `from openai import OpenAI` is reached (openai is importable;
+    #     the import precedes the api-key check, so no key needed).
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", True)
+    fired_b = {"v": False}
+    real_import = builtins.__import__
+
+    def _trap_import(name, *a, **k):
+        if name == "openai" or name.startswith("openai."):
+            fired_b["v"] = True
+            raise AssertionError("provider import reached")
+        return real_import(name, *a, **k)
+    monkeypatch.setattr(builtins, "__import__", _trap_import)
+    try:
+        nlq.classify_question("anything")
+    except BaseException:  # noqa: BLE001
+        pass
+    monkeypatch.setattr(builtins, "__import__", real_import)
+    assert fired_b["v"], "__import__ trap did NOT fire flag-on — vacuous"
+    monkeypatch.undo()
+
+    # (c) `socket.connect` trap — proves the network-layer trap bites.
+    #     Real _client() + real import + OpenAI(api_key=dummy)
+    #     (construction is network-free); the outbound connect happens
+    #     in _invoke()'s completions call → the trap fires there.
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", True)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-not-a-real-key-for-trap-test")
+    monkeypatch.setattr(nlq, "_llm_client", None)  # force re-construct
+    fired_c = {"v": False}
+    real_connect = socket.socket.connect
+
+    def _trap_connect(self, *a, **k):
+        fired_c["v"] = True
+        raise AssertionError("outbound connect reached")
+    monkeypatch.setattr(socket.socket, "connect", _trap_connect)
+    try:
+        nlq.classify_question("anything")
+    except BaseException:  # noqa: BLE001
+        pass
+    monkeypatch.setattr(socket.socket, "connect", real_connect)
+    assert fired_c["v"], "socket.connect trap did NOT fire flag-on — vacuous"
+
+
+def test_direct_client_call_also_refuses_when_disabled(monkeypatch):
+    """Defence in depth: even a DIRECT `_client()` call (bypassing
+    classify_question) refuses with the flag off — the provider import
+    is never reached."""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", False)
+    with pytest.raises(RuntimeError, match="NL_QUERY_LLM_ENABLED off"):
+        nlq._client()
+
+
+# ===========================================================================
+# The /ask endpoint with the flag off — the named gate at the HTTP surface
+# ===========================================================================
+
+from fastapi import FastAPI                                     # noqa: E402
+from fastapi.testclient import TestClient                       # noqa: E402
+
+import app.api.query as query_api                               # noqa: E402
+from app.api.auth import get_current_user                       # noqa: E402
+
+
+def _app_and_client(monkeypatch, *, recorder=None):
+    """Minimal app mounting the real query router; only get_current_user
+    overridden, so the REAL require_capability gate runs (PR A's
+    test_query_api harness). A run_template recorder proves the
+    no-new-data-path property when wired."""
+    app = FastAPI()
+    app.include_router(query_api.router)
+
+    if recorder is not None:
+        def fake_run_template(supabase, template_id, params, *, workspace_id):
+            recorder["run_template"] = {
+                "template_id": template_id, "params": params,
+                "workspace_id": workspace_id,
+            }
+            from ontology.query.result import (
+                Provenance, QueryResult, QueryRow,
+            )
+            return QueryResult(
+                template_id=template_id, template_version=1,
+                workspace_id=workspace_id,
+                rows=[QueryRow(data={"patient_id": "p1"},
+                               provenance=Provenance(source_kind="diagnosis",
+                                                     source_document_id="d1"))],
+                row_count=1, data_maturity="populated",
+            )
+
+        def fake_resolve(supabase, result, *, workspace_id):
+            recorder["resolve_provenance"] = {"workspace_id": workspace_id}
+            return result  # to_dict() is enough for the assertions
+
+        # patch on a tiny shim object so .to_dict() works
+        class _R:
+            def __init__(self, r): self._r = r
+            def to_dict(self): return {"rows": [], "row_count": self._r.row_count}
+
+        monkeypatch.setattr(query_api, "run_template", fake_run_template)
+        monkeypatch.setattr(query_api, "resolve_provenance",
+                            lambda s, r, *, workspace_id: (
+                                recorder.__setitem__(
+                                    "resolve_provenance",
+                                    {"workspace_id": workspace_id}) or _R(r)))
+        monkeypatch.setattr(query_api, "_sb", lambda: object())
+
+    def make_user(**over):
+        u = {"email": "doc@x", "workspace_id": "ws-AUTH",
+             "capabilities": ["clinical_query"]}
+        u.update(over)
+        return u
+
+    app.dependency_overrides[get_current_user] = lambda: make_user()
+    app.state._make_user = make_user
+    return app, TestClient(app), make_user
+
+
+def test_ask_endpoint_hard_refuses_when_disabled(monkeypatch):
+    """Named gate at the HTTP surface. Real router + REAL
+    require_capability (only get_current_user overridden), flag off:
+    POST /api/query/ask returns the feature-gated refusal with the
+    answerable list; run_template is never called; no _sb()/network."""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", False)
+
+    called = {"run_template": False, "sb": False}
+    monkeypatch.setattr(query_api, "run_template",
+                        lambda *a, **k: called.__setitem__("run_template", True))
+    monkeypatch.setattr(query_api, "_sb",
+                        lambda: called.__setitem__("sb", True))
+
+    _app, client, _mk = _app_and_client(monkeypatch)
+    r = client.post("/api/query/ask",
+                    json={"question": "show me Jane Doe's medications"})
+    assert r.status_code == 403
+    body = r.json()["detail"]
+    assert body["reason"] == "nl_disabled"
+    assert body["answerable"], "refusal must carry the answerable list"
+    assert called == {"run_template": False, "sb": False}
+
+
+# ===========================================================================
+# Output-domain constraint — the drift gate (registry ⇔ tool schema)
+# ===========================================================================
+
+def test_tool_schema_is_exactly_the_registry():
+    """The anti-drift gate. The model's entire callable surface is the
+    registry-derived tool set + the synthetic `refuse` — it cannot list
+    an unregistered template, omit a registered one, or surface a
+    `validator` (callable, unserialisable). Same drift-impossible status
+    as PR B's registry-iterating invariants."""
+    from ontology.query import all_templates
+
+    tools = nlq.build_tool_schema()
+    names = {t["function"]["name"] for t in tools}
+    registry_ids = {t.id for t in all_templates()}
+    assert names == registry_ids | {nlq.REFUSE_TOOL}
+
+    by_name = {t["function"]["name"]: t for t in tools}
+    for tpl in all_templates():
+        params = by_name[tpl.id]["function"]["parameters"]
+        assert set(params["properties"]) == {p.name for p in tpl.params}
+        assert set(params["required"]) == {
+            p.name for p in tpl.params if p.required
+        }
+    # No validator / no callable anywhere in the serialised schema.
+    blob = json.dumps(tools, default=lambda o: "<UNSERIALISABLE>")
+    assert "<UNSERIALISABLE>" not in blob
+    assert "validator" not in blob
+
+
+# ===========================================================================
+# Mocked-LLM WIRING (NOT intelligence — labelled). Flag ON, fake _invoke.
+# ===========================================================================
+
+def _fake_resp(tool_name, args: dict | None, *, no_tool=False, bad_json=False):
+    if no_tool:
+        msg = types.SimpleNamespace(tool_calls=[])
+    else:
+        arg_str = "{not json" if bad_json else json.dumps(args or {})
+        fn = types.SimpleNamespace(name=tool_name, arguments=arg_str)
+        msg = types.SimpleNamespace(
+            tool_calls=[types.SimpleNamespace(function=fn)])
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message=msg)])
+
+
+def _enable_with_fake(monkeypatch, resp):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", True)
+    monkeypatch.setattr(nlq, "_client", lambda: object())  # never network
+    monkeypatch.setattr(nlq, "_invoke",
+                        lambda client, messages, tools, model: resp)
+
+
+@pytest.mark.parametrize("tpl,params", [
+    ("patients_with_diagnosis_prefix", {"icd10_prefix": "E11"}),
+    ("patients_not_seen_since", {"days_since": 180}),
+    ("patient_active_medications", {"patient_id": "p1"}),
+    ("patient_recent_consultations", {"patient_id": "p1", "limit": 5}),
+    ("patients_with_abnormal_recent_vitals", {"within_days": 90}),
+    ("patient_open_documents", {}),
+    ("patients_with_lab_threshold", {"test_code": "HBA1C"}),
+])
+def test_wiring_passes_tool_selection_through_uninterpreted(
+        monkeypatch, tpl, params):
+    """WIRING ONLY — proves: given the model selects tool T with args A,
+    classify_question returns NLClassification(T, A) with params passed
+    through UNINTERPRETED (the runner validates, not this module). It
+    does NOT prove the model picks T for any real phrasing — that is
+    accuracy, unverified at merge, only knowable via the opt-in eval."""
+    _enable_with_fake(monkeypatch, _fake_resp(tpl, params))
+    out = nlq.classify_question("(phrasing irrelevant — LLM mocked)")
+    assert isinstance(out, nlq.NLClassification)
+    assert out.template_id == tpl
+    assert out.params == params  # uninterpreted passthrough
+
+
+# ===========================================================================
+# Refusal matrix — Decision-4 hazard shapes (NOT generic gibberish)
+# ===========================================================================
+
+def test_refuse_tool_yields_refusal_with_answerable_list(monkeypatch):
+    _enable_with_fake(monkeypatch, _fake_resp(nlq.REFUSE_TOOL, {}))
+    out = nlq.classify_question("something the model declines")
+    assert isinstance(out, nlq.NLRefusal)
+    assert out.reason == "out_of_set"
+    assert {a["id"] for a in out.answerable}  # non-empty answerable list
+
+
+def test_hallucinated_unregistered_tool_is_refused_never_executed(monkeypatch):
+    """A plausible-but-unregistered shape: the model names a tool that
+    is not in the registry. Must refuse with the answerable list, NEVER
+    approximate to the nearest template, never execute."""
+    _enable_with_fake(monkeypatch,
+                      _fake_resp("patients_with_unicorns", {"x": 1}))
+    out = nlq.classify_question("how many unicorn patients do I have")
+    assert isinstance(out, nlq.NLRefusal)
+    assert out.reason == "out_of_set"
+    assert any(a["id"] == "patients_with_diagnosis_prefix"
+               for a in out.answerable)
+
+
+def test_no_tool_call_is_refused(monkeypatch):
+    _enable_with_fake(monkeypatch, _fake_resp(None, None, no_tool=True))
+    out = nlq.classify_question("...")
+    assert isinstance(out, nlq.NLRefusal)
+    assert out.reason == "low_confidence"
+
+
+def test_malformed_arguments_are_refused_not_guessed(monkeypatch):
+    _enable_with_fake(monkeypatch,
+                      _fake_resp("patient_active_medications", None,
+                                 bad_json=True))
+    out = nlq.classify_question("meds for someone")
+    assert isinstance(out, nlq.NLRefusal)
+    assert out.reason == "low_confidence"
+
+
+def test_near_miss_pair_one_maps_one_refuses(monkeypatch):
+    """The Decision-4 hazard the structural gates CANNOT see: two
+    phrasings differing by a clinically material term — one is a valid
+    mapping, the near-miss must refuse. WIRING form: we fixture the
+    model's *decision* (accuracy is the eval's job, not this test's);
+    this proves the SYSTEM executes the mapped one and refuses the
+    refused one, never approximating. The model actually making that
+    call correctly is accuracy — unverified at merge, labelled."""
+    # Phrasing A — maps cleanly.
+    _enable_with_fake(monkeypatch,
+                      _fake_resp("patients_not_seen_since",
+                                 {"days_since": 180}))
+    a = nlq.classify_question("patients not seen in 6 months")
+    assert isinstance(a, nlq.NLClassification)
+    assert a.template_id == "patients_not_seen_since"
+    # Phrasing B — the near-miss (e.g. "patients I should NOT see again")
+    # — the model (correctly) declines; the system must refuse, not
+    # approximate to patients_not_seen_since.
+    _enable_with_fake(monkeypatch, _fake_resp(nlq.REFUSE_TOOL, {}))
+    b = nlq.classify_question("patients I should not see again")
+    assert isinstance(b, nlq.NLRefusal)
+    assert b.reason == "out_of_set"
+
+
+# ===========================================================================
+# No new data path + tenant scope (mirrors PR A's forged-body-inert)
+# ===========================================================================
+
+def test_ask_reaches_data_only_through_run_template(monkeypatch):
+    """A successful /ask reaches data via EXACTLY
+    run_template→resolve_provenance — the same chokepoint /run uses,
+    nothing else. The classifier is mocked to a fixed mapping (wiring,
+    not accuracy)."""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", True)
+    monkeypatch.setattr(
+        nlq, "classify_question",
+        lambda q, **k: nlq.NLClassification(
+            template_id="patient_active_medications",
+            params={"patient_id": "p1"}))
+
+    rec: dict = {}
+    _app, client, _mk = _app_and_client(monkeypatch, recorder=rec)
+    r = client.post("/api/query/ask",
+                    json={"question": "what is p1 on",
+                          "workspace_id": "ws-EVIL"})  # forged — inert
+    assert r.status_code == 200, r.text
+    # The runner got the AUTH workspace, never the forged body value.
+    assert rec["run_template"]["workspace_id"] == "ws-AUTH"
+    assert rec["run_template"]["template_id"] == "patient_active_medications"
+    assert "resolve_provenance" in rec  # the only other data touchpoint
+    assert r.json()["interpreted_as"] == {
+        "template_id": "patient_active_medications",
+        "params": {"patient_id": "p1"},
+    }
+
+
+def test_ask_capability_gated(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", True)
+    app, client, mk = _app_and_client(monkeypatch)
+    app.dependency_overrides[get_current_user] = lambda: mk(capabilities=[])
+    r = client.post("/api/query/ask", json={"question": "anything"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["capability"] == "clinical_query"
+
+
+def test_ask_requires_workspace(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "NL_QUERY_LLM_ENABLED", True)
+    monkeypatch.setattr(
+        nlq, "classify_question",
+        lambda q, **k: nlq.NLClassification("patient_open_documents", {}))
+    app, client, mk = _app_and_client(monkeypatch)
+    app.dependency_overrides[get_current_user] = lambda: mk(workspace_id=None)
+    r = client.post("/api/query/ask", json={"question": "open docs"})
+    assert r.status_code == 400


### PR DESCRIPTION
## Summary

Phase 3, **PR C** — the thinnest natural-language mapping onto the
CLOSED query-template registry. **Ships DISABLED.** NL is the steering
wheel; the provenance-verifiable primitives (PR A/B) are the brakes —
brakes shipped and proven first, steering wheel ships locked until an
operator deliberately enables it.

Grounded in fresh live-codebase probes (2026-05-16) — see
[ONTOLOGY_PHASE3_PRC_PLAN.md](ONTOLOGY_PHASE3_PRC_PLAN.md) §1. Plan
approved at review; four decisions closed; two required tightenings
applied.

## The one property the merge stands on (built first, proven un-mockable)

> *With `NL_QUERY_LLM_ENABLED` unset (the merge default — the env var is
> absent and no commit sets it), there is NO path that constructs an LLM
> client or makes any outbound network call, and `POST /api/query/ask`
> hard-refuses without sending the question text — which can itself be
> PII (a patient name) — anywhere. There is NO scrubber and this code
> does not pretend one (a reliable name-stripper is itself unsolved;
> claiming it would be the Phase-2 fake-property anti-pattern). The
> disabled-default IS the PII safety boundary.*

Enforced structurally (provider import lives ONLY inside `_client()`;
the flag check is the first executable statement of `classify_question`,
returning a hard refusal before `_client()`, before any import, before
any network) and proven by a NAMED, un-mockable CI gate built and
verified **before** the classifier or endpoint existed:

- `test_nl_disabled_constructs_no_client_and_makes_no_network_call` —
  real `classify_question`, flag off, a deliberately PII-bearing input,
  **three independent traps** (a `_client` sentinel, a
  `socket.socket.connect` trap, an `__import__` trap on the provider
  module). All three must stay silent. Three layers because the
  regression is a future refactor moving the import to module scope or
  calling `_client()` before the gate — a single trap at the wrong
  layer would miss it. Same shape as PR A's silent-dead-link guard / PR
  B's inertness gate.
- `test_ask_endpoint_hard_refuses_when_disabled` — through the real
  router + real `require_capability` (only `get_current_user`
  overridden), flag off: `/ask` returns the feature-gated refusal +
  answerable list; `run_template` never called; no `_sb()`/network.
- `test_default_is_structurally_off` — the real setting is `False`
  with zero monkeypatching (the merge default is structural).
- **`test_traps_are_non_vacuous_each_fires_with_flag_ON` — the
  discriminating check.** PR C has no external contradicting surface
  (no live DB / HTTP chain), so the gate test *is* the entire
  verification; a gate proven only by silence could be passing because
  the trap-guarded path was never reached. This shipped test proves the
  opposite: with the flag **ON**, each of the three traps **fires** on
  the thing it guards — (a) the `_client` sentinel fires when
  construction is reached; (b) the `__import__` trap fires when
  `from openai import OpenAI` is reached (the real `_client()` runs);
  (c) the `socket.connect` trap fires when `_invoke()`'s completion
  call attempts to connect. The traps are real instruments, not inert
  decorations — so the flag-OFF silence is meaningful evidence the
  boundary held, not a vacuous pass. (Same discipline as PR B's
  `module_digitisation` ratchet proven non-vacuous by showing it
  *bites*; established two PRs ago, applied here because on a PR whose
  entire safety is one structural gate, "shown to bite" must sit in the
  permanent record next to "stayed silent" or the record tells half
  the proof.)

## What ships

- **`app/services/nl_query.py`** — constrained classifier. `build_tool_schema()`
  derives one tool per registered template from `all_templates()` every
  call (the tool set IS the registry — cannot drift, cannot name an
  unregistered template, never surfaces a `validator`) plus a synthetic
  `refuse`. `classify_question()` gate-first; `tool_choice="required"`
  over the closed set; anything unexpected → hard refusal **with the
  answerable list, never a guess**. Params passed **uninterpreted** (the
  runner is the single validation authority — NL2SQL rejected outright).
  `_client()` lazy+gated (mirrors `semantic_search._client()`), provider
  call isolated to `_invoke()`.
- **`app/api/query.py` `POST /api/query/ask`** — mirrors `/run`'s auth,
  rate-limit, tenant-scope (workspace from auth ONLY; the request model
  has only `question`). A successful classification runs through the
  **identical `run_template`+`resolve_provenance` chokepoint** — there
  is NO other path to data, proven by recorder
  (`test_ask_reaches_data_only_through_run_template`), so NL answers
  structurally inherit PR A/B's verifiable-provenance contract. Response
  carries `interpreted_as` so the caller can see (and catch) a
  misclassification.
- **`config.py`** — `NL_QUERY_LLM_ENABLED` on `Settings`, the
  `DEBUG`/`ENABLE_METRICS` house pattern, default-off structural.
- **`tests/test_nl_query.py`** — the two named gates, the
  `test_tool_schema_is_exactly_the_registry` drift gate, wiring
  passthrough ×7 (WIRING ONLY — labelled), the Decision-4 refusal
  matrix (refuse-tool, hallucinated/unregistered, no-tool, malformed
  args, the near-miss pair), no-new-data-path + forged-body-inert,
  capability/tenant. **20/20 green.**
- **`scripts/nl_query_eval.py`** — opt-in real-LLM accuracy eval,
  two-step authorisation (`NL_QUERY_LLM_ENABLED` on AND
  `--i-have-authorised-a-provider`), NEVER CI, accuracy reported never
  gated; carries the 1-canonical+1-paraphrase-per-template golden set
  and the hazard-shape adversarial set.

## Decision #3 — coherent choice pays twice (stated for the record)

`/ask` reuses `clinical_query` (NOT a new capability). This is the
coherent choice — `/ask` reaches *exactly* the same data through the
same chokepoint; a capability narrower than the data it exposes is
incoherent (the locked-decision-#4 logic). It pays twice: **PR A's
`module_digitisation`-does-NOT-entail-`clinical_query` Type-C ratchet
(`test_module_digitisation_never_entails_clinical_query`) automatically
covers the NL surface by construction** — the written Type-C customer
promise is enforced on `/ask` for free, zero new ratchet code, *because*
the capability was reused rather than minted. A distinct
`clinical_query_nl` was rejected: it would have needed a
migration-025-style seed AND a new ratchet to keep the Type-C promise;
the reuse inherits both for free.

## Construct-validity / honesty ledger (verbatim)

| Claim | Verified by | Label |
|---|---|---|
| Flag off ⇒ no client, no outbound call, `/ask` hard-refuses w/o sending text | the two named gate tests (DB/network-free, real fn/router, 3 traps) | **structural invariant — proven, load-bearing** |
| Tool schema cannot drift from the registry | `test_tool_schema_is_exactly_the_registry` | **structurally enforced, proven** |
| Output domain = {registered id}×{params} ∪ refusal (no SQL/free-form/unregistered) | drift gate + refusal matrix | **proven by construction** |
| NL adds no new data path; rides `run_template`+`resolve_provenance` | `test_ask_reaches_data_only_through_run_template` + forged-body-inert | **proven** |
| Mocked tests prove the *wiring* (tool-call → chokepoint → envelope) | `test_nl_query.py` mocked client | **WIRING ONLY — explicitly NOT classifier intelligence/accuracy** |
| Classifier picks the *right* template for a real phrasing | `nl_query_eval.py`, opt-in, never CI | **mapping-correctness — UNVERIFIED at merge; only knowable with the LLM enabled; reported, NEVER gated** |
| PII never reaches an LLM at merge | the disabled-default boundary (no scrubber) | **the boundary is the flag, NOT a scrubber — the question itself can be PII; stated unsoftened** |

Nothing verifiable only with the LLM enabled is presented as proven. No
mock/fixture appears anywhere as accuracy evidence.

## What PR C earns — two claims, deliberately UN-fused

**PROVEN at merge — the output-domain constraint.** The classifier
cannot emit SQL, free-form, or an unregistered template; it rides the
same chokepoint as `/run`; ships disabled with that disabled-default a
structural CI invariant.

**NOT verified at merge — mapping correctness.** Whether the classifier
picks the *right* registered template for a real phrasing is entirely
unverified. "Constrained to the closed enum" means
*output-domain-constrained*, **never** *mapping-correct*: the classifier
can pick the *wrong registered template*, confidently, and that wrong
answer still passes the runner, still gets provenance-resolved, still
looks authoritative — **the misclassification failure is inside the
safety envelope of every structural gate this PR ships and is invisible
to all of them.** Knowable only via the opt-in eval once a provider is
authorised. Named here unsoftened, exactly as the ledger names it (the
PR-A/PR-B earns-section overclaim, third occurrence, same cure: split
the sentence).

## Deferred (named at the cheap boundary)

- Enabling the LLM / provider authorisation — governance act, user-deferred.
- **Shared rate-limit bucket:** `/ask` reuses `/run`'s 30/60s bucket;
  inert with the flag off; the day it is enabled `/ask` and `/run`
  share one budget. The **flag-enablement governance review must decide
  whether `/ask` needs its own bucket** — named here, tracked in memory,
  not discovered in production.
- Standing-query materialisation + Phase 3 close-out + the
  conversion-instrumentation named note — **PR D** (not absorbed here).
- POPIA query-access logging — Phase 5; NL rides the existing
  `run_template` chokepoint so it inherits that future decorator slot
  for free (a positive consequence of "no new data path").

## Test plan

- [x] `test_nl_query.py` 21/21 green: the two named gates incl. the
      un-mockable 3-trap default-off proof, **the trap-non-vacuity
      proof (flag-ON each trap fires — the gate is shown to bite, not
      just stay silent)**, drift gate, wiring ×7, Decision-4 refusal
      matrix, no-new-path, capability/tenant.
- [x] Full DB-free query suite: **73 passed, 1 skipped** (PR A/B's 52
      unchanged — PR C is additive: `/run`, `/templates`, resolver,
      registry untouched — + PR C's 21; the 1 skip is the
      RUN_INTEGRATION suite, correctly skipped).
- [x] `server.py` + `main.py` import clean with `/api/query/ask`
      mounted — no regression.
- [ ] `nl_query_eval.py` — operator-only, opt-in, never CI; run only
      after a provider is authorised (governance act, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
