### PR TITLE
Phase 4 PR F — OpenLoop substrate: object + closed non-vacuous state machine + audited reversible actions

### DIFF
--- a/ONTOLOGY_PHASE4_PRF_PLAN.md
+++ b/ONTOLOGY_PHASE4_PRF_PLAN.md
@@ -1,0 +1,563 @@
+# Phase 4 — PR F Implementation Plan: `OpenLoop` as the Fourth Ontology Object (+ state machine, audited actions, migration 028)
+
+> **Status:** plan APPROVED at review at the A/B/C/D bar. **F-1, F-2,
+> F-3, F-4 FINAL (locked, §6).** Grounded in fresh read-only probes of
+> the live codebase **2026-05-17, `main`@`51d1664`** (own probes + two
+> recon sweeps, every load-bearing claim file:line-verified, not taken
+> from the umbrella's subagent summary — the §D.1 lesson). Implements
+> umbrella **locked Decision 3** (stateful-vs-derived split) and its
+> forward requirement (per-loop-type classification *with reasoning*);
+> no umbrella decision re-opened. **F-1 = option B** (substrate + state
+> machine + audited actions ONLY; first real stateful loop deferred to
+> PR G) **with the non-vacuity rider**: the construct-validity tests
+> must be **proven non-vacuous by asserted rejection of illegal
+> transitions — the §D.1 mechanism** (a state machine "proven" only by
+> feeding it valid transitions is the §D.1 false-green in a new place;
+> the honest claim option B may make is "shown to reject what it must
+> reject", not merely "works on well-formed fabricated input"). F-2/F-3/
+> F-4 locked with riders (§6). The §2.1 falsification is recorded as the
+> §2.0 §D.1-class premise-test note so a future maintainer inherits the
+> finding and does NOT re-derive "refactor" from the umbrella's stale
+> word. No code until §3.1/§4/§5 carry the non-vacuity rider in their
+> explicit test scope (done below).
+>
+> **Premise the probe corrected (norm #1 — verify before asserting; same
+> register as PR D Finding W and PR E Finding L4):** the umbrella's PR F
+> scope says *"refactor scattered existing follow-up logic into it so
+> OpenLoop is the audited source of loop state."* **The live code
+> falsifies the premise that genuinely-stateful follow-up logic exists
+> to refactor.** Probed against the actual code, *every* existing
+> follow-up mechanism is either a **stateless recomputed cohort** (no
+> stored per-row state, no closing trigger) or a **write-once record
+> with an inert status field**. By locked Decision 3 the stateless ones
+> **stay standing queries — they are NOT refactor targets**; nothing
+> currently keeps loop *state* anywhere to move into `OpenLoop`. PR F is
+> therefore **not a refactor of existing state** — it is the
+> introduction of the `OpenLoop` substrate + state machine, proven on a
+> **deliberately-built first stateful loop**, and *which* loop (or
+> none-in-PR-F) is a **reserved scoping decision (§6 F-1)**, surfaced
+> here, not chosen under pressure. This is PR F's load-bearing finding
+> and it is scoped FIRST (§2), brakes-before-wheel, exactly as PR D
+> scoped its close-out and PR E its contrast-fork before any code.
+>
+> **The locked-Decision-3 inverse hazard, restated because this is
+> exactly where it bites:** Decision 3 warned against classifying a
+> genuinely-stateful loop as *derived* to dodge state-machine work. The
+> live finding shows the *symmetric* hazard is the live one: the
+> temptation to classify the stateless cohorts as *stateful* "because
+> they're called follow-up", and to **invent** an `acknowledged_on` /
+> `closed_by` lifecycle the current code does not have. Both directions
+> are misclassification; §2 classifies each on *what the code actually
+> does*, file:line, not on the word "follow-up".
+
+---
+
+## 1. Empirical findings (live codebase, read-only, 2026-05-17 `main`@`51d1664`)
+
+### Finding F1 — every existing follow-up mechanism is DERIVED or write-once-inert (the load-bearing fact)
+
+Code-level characterisation, file:line, strictly on what the code *does*:
+
+| Mechanism | File:line | What the code does | Lifecycle? |
+|---|---|---|---|
+| Procedures follow-up | `backend/api/procedures.py:46-47,291-311` | `follow_up_required`/`follow_up_date` set at create; `GET /procedures/follow-up/due` recomputes `follow_up_date <= today` at query time; `PUT` allows arbitrary field mutation; **no endpoint/trigger ever closes a follow-up** | **STATELESS** — recomputed cohort, no stored per-row state, no closing trigger |
+| Immunizations overdue | `backend/api/immunizations.py:42-43,295-316` | `next_dose_due`/`series_complete`; `GET /immunizations/overdue` recomputes `series_complete=false AND next_dose_due < today`; "overdue" is **never stored**; `series_complete` marks series end, not per-dose compliance | **STATELESS** — "overdue" is a query-time comparison, no stored compliance state, no closing trigger |
+| Referrals | `backend/server.py:251-283,4908-4963`; `database/phase_4_2_schema.sql:52-71` | `POST /referrals` inserts with hard-coded `status='pending'`; schema *defines* `pending/sent/completed/cancelled`; **no API endpoint mutates status**; no `PUT`; no deadline | **WRITE-ONCE / INERT** — status field present but never transitioned in code; a lifecycle only *exists if PR F builds it* |
+| `EncounterType.FOLLOW_UP` | `backend/ontology/enums/consultation_enums.py:34` | A classifier label on an immutable encounter; may *trigger* future detection, holds no state itself | **CLASSIFIER** — not a state machine |
+| `morning_briefing` / `patients_not_seen_since` | `backend/ontology/query/standing.py:123-128,188-235` | Recomputed cohort materialised per `as_of_date`; a patient leaves implicitly via a new encounter; no per-row state, no audit, no closing trigger | **STATELESS** — the canonical DERIVED example (Decision 3's reference) |
+| `OpenLoop` | — | Grep across `backend/`: only in design docstrings (`executor.py`, `patient.py`, `consultation_enums.py`, `consultation.py`); **no object, table, or endpoint** | **CONFIRMED ABSENT** |
+
+**Consequence:** applying locked Decision 3 honestly, *nothing existing
+is a stateful loop*. The stateless cohorts stay standing queries (not
+refactored). Referrals are the only thing with a *latent* lifecycle, and
+only because a schema column names states the code never transitions —
+making them stateful is **building new state-machine logic, not
+refactoring existing state**.
+
+### Finding F2 — the ontology-object template `OpenLoop` must conform to (verified)
+
+`backend/ontology/base.py`: `OntologyObject` base (model_config
+`extra="forbid", validate_assignment=True, str_strip_whitespace=True`,
+inherited — do not override); `Prop(default, *, pii, fhir, search,
+display_label, description, link_to, link_cardinality,
+immutable_after_create, deprecated, **field_kwargs)`; ClassVars
+`__object_type_name__`, `__display_template__`, `__fhir_resource__`,
+`__pii_level__` (`PIILevel.NONE|LOW|MEDIUM|HIGH|SPECIAL`), `__audited__`;
+inherited system fields `id`, `practice_id` (link_to="Practice"),
+`created_at`, `updated_at`, `deleted_at` (all `Prop(...)`,
+`immutable_after_create` where appropriate). Validators:
+`@field_validator` + `@model_validator(mode="after")` (Pydantic v2).
+Template object: `backend/ontology/objects/patient.py`. Export wiring:
+add to `backend/ontology/__init__.py` import + `__all__` (objects/
+`__init__.py` is empty by design).
+
+### Finding F3 — the links registry pattern (verified)
+
+`backend/ontology/links/registry.py`: `@dataclass(frozen=True) LinkType{
+name, source_type, target_type, cardinality: Cardinality
+(ONE_TO_ONE|ONE_TO_MANY|MANY_TO_MANY), inverse_name, description,
+link_properties: tuple=(), explicit_table: Optional[str]=None}`; links
+declared by appending `LinkType(...)` to the `LINKS` tuple; an object's
+`Prop(link_to="X", link_cardinality="one|many")` is mirrored by a
+matching `LinkType`; helpers `get_links_from/to`, `find_link`.
+
+### Finding F4 — the audited-action + reversal template (verified)
+
+`backend/app/actions/base.py`: `Action` ABC — ClassVars
+`__action_name__`, `__action_version__`, `__reversible__`,
+`__pii_level__`; abstract `preconditions()→List[Precondition]`,
+`effects()→List[Effect]`, `describe_for_user()`,
+`to_audit_parameters()`, classmethod `from_audit_parameters()`.
+`Precondition.check(ctx)→CheckResult`; `Effect.plan(ctx)→EffectDescriptor`
++ `apply(ctx)→EffectResult`; `ExecutorContext.append_affected_object(
+object_type,object_id,op∈{created,updated,soft_deleted,linked})`.
+Entrypoint `backend/app/actions/executor.py: execute(action, *, actor,
+supabase, practice_id, workspace_id, dry_run, idempotency_key)`. Audit
+row `migrations/014_action_audit_log.sql` (parameters,
+preconditions_checked, effects_applied, affected_objects, outcome∈
+{success,precondition_failed,effect_failed,reversed,dry_run},
+reverses_audit_id, reversed_by_audit_id). Reversal: RPC-backed
+(`_REVERSE_RPC_FOR_ACTION`) OR Python-side
+(`register_python_reversal(name, builder)` at module import — the
+`SoftDeletePatient` template, `ontology/actions/soft_delete_patient.py`,
+is the closest analog: single-table state change, Python-side reversal).
+Primitives `backend/app/actions/primitives.py`: `ObjectExists`,
+`HasStatus`, `NotSoftDeleted`, `BelongsToPractice`, `HasPermission`;
+`SetField`, `SetMultipleFields`, `SoftDelete`, `RestoreSoftDeleted`.
+Register action modules in `backend/app/actions/registered.py`
+(one import line each, `@register_action @dataclass(eq=False)`).
+
+### Finding F5 — migration / RLS / ratchet / worker facts (verified)
+
+- **Next free migration = 028** (highest on `main` is `027_briefing_
+  items.sql`; PR E added none).
+- **migration-018 RLS-deny-all idiom (028 reproduces verbatim):**
+  `ALTER TABLE … ENABLE ROW LEVEL SECURITY`, **no permissive policy**,
+  **NOT FORCE** (`018:36` rationale — FORCE would also constrain the
+  service_role backend), **NOT auth.*-keyed** (`018:43-46` — app is not
+  Supabase-Auth; an auth.* policy is dead code). Deny-all to
+  anon/authenticated; service_role bypasses. Exactly what `027`
+  reproduced.
+- **PR-5 tenant guard ratchet** (`tests/test_tenant_query_isolation.py`):
+  `TENANT_TABLES: Set[str]` (`:65`) + frozen `BASELINE` of
+  `"relpath::lineno::table"` (`:212`); `test_no_new_unscoped_tenant_
+  queries` (`:344`) fails on `current-BASELINE` AND `BASELINE-current`
+  (ratchet only goes down). A **born-workspace-scoped** `open_loops`
+  (every chain carries `.eq("workspace_id",…)`) added to `TENANT_TABLES`
+  adds **zero new BASELINE keys** — the exact posture `briefing_items`
+  took.
+- **NOTIFY pgrst:** `028` adds a TABLE and no function — the **`027`
+  decided-inclusion reasoning applies verbatim** (REST-builder-addressed
+  table; stale schema-cache 404s; NOTIFY is the cheap correct hygiene),
+  stated explicitly in the `028` header as a *decided* inclusion, not
+  cargo-culted in either direction.
+- **Worker host** (`server.py:5361` `@app.on_event("startup")`,
+  singleton `create_task` pattern): relevant only to loop *detectors*.
+  Per the umbrella PR breakdown detectors are **PR G**; PR F adds the
+  object/state-machine/actions and **no worker** (a scoping note, §6).
+
+---
+
+## 2.0 §D.1-class premise-test note — "refactor existing follow-up logic" is FALSIFIED; PR F is an introduction, not a refactor (recorded so it is NOT re-derived)
+
+> Same register as the post-mortem's §D/§D.1 and PR E's §2.0: not
+> failure narration — a premise that read sound in the umbrella and was
+> tested at PR-F plan time against the live code and found false. A
+> future maintainer (PR G, or anyone re-reading the umbrella) must
+> inherit the *finding*, not re-derive "refactor" from the umbrella's
+> stale word.
+
+The umbrella's PR F scope line — *"refactor scattered existing
+follow-up logic into it so OpenLoop is the audited source of loop
+state"* — was reviewed and approved at umbrella time. At PR-F plan time
+its premise was probed against the actual code (§1 Finding F1,
+file:line) and **falsified**: there is **no genuinely-stateful
+follow-up logic anywhere to refactor.** Every candidate is a stateless
+recomputed cohort (procedures-follow-up, immunisations-overdue,
+patients-not-seen-since — all `< today` query-time comparisons, no
+stored per-row state, no closing trigger) or a write-once record with
+an **inert** status field never transitioned by any code (referrals).
+By locked Decision 3 the stateless ones **stay standing queries — they
+are not refactor targets**; nothing currently keeps loop *state*
+anywhere to move into `OpenLoop`.
+
+**Therefore PR F is the *introduction* of `OpenLoop` (substrate + state
+machine + audited mutation actions), not a refactor of pre-existing
+state.** The umbrella word "refactor" is stale; PR F (and PR G, and any
+future reader) must treat the existing follow-up mechanisms as
+classified in §2.1 — DERIVED → standing queries, referral →
+write-once-inert (a real loop only if *built*, which is PR-G taxonomy
+work, F-4-locked) — and must NOT invent an `acknowledged_on`/`closed_by`
+lifecycle on the stateless cohorts to make PR F look like a refactor
+(the symmetric misclassification, the live hazard). This note is the
+named anchor; the finding is inherited, not re-derived. See
+[[project-phase4-pr-e-option2-gate]] (the sibling Phase-4
+premise-correction) and [[feedback-verify-premise-boring-first]].
+
+---
+
+## 2. The load-bearing part of PR F — the per-loop-type classification + the premise it forces (scoped FIRST, locked-Decision-3 forward requirement)
+
+> **This section is PR F's brakes.** Locked Decision 3 *requires* the
+> per-loop-type stateful/derived classification with reasoning in this
+> plan. Done honestly against Finding F1 it produces a premise-correction
+> that reshapes PR F's scope — resolved by the locked F-1 decision
+> (option B, §2.2 + §6) BEFORE the object/migration/action code.
+
+### 2.1 The classification, per type, with reasoning (on what the code does — not the word "follow-up")
+
+| Loop type | Classification | Reasoning (code-grounded) |
+|---|---|---|
+| Patients-not-seen-since (recall) | **DERIVED** | Recomputed cohort; leaves implicitly via a new encounter; no per-row state/audit/closing trigger (`standing.py:188-235`). Stays a standing query. Adding `acknowledged_on` would *invent* a lifecycle — the inverse misclassification. |
+| Procedures-follow-up-due | **DERIVED** | `follow_up_date < today` recomputed at query time; nothing closes it (`procedures.py:291-311`). Stateless. Stays a (future PR-G) standing query; not an `OpenLoop`. |
+| Immunisation-overdue | **DERIVED** | `next_dose_due < today` recomputed; "overdue" never stored (`immunizations.py:295-316`). Stateless. Standing query, not `OpenLoop`. |
+| Specialist-referral-pending | **STATEFUL — but NOT existing; would be NEWLY BUILT** | Referrals are write-once with an inert `status` (`server.py:4908-4945`); the schema *names* `pending/sent/completed/cancelled` but no code transitions it. A real loop here = PR F **building** open→awaiting→closed/breached + deadline + audited transitions. Genuinely stateful (an opening event, an expected closing event — the specialist letter — a deadline, a breach) — *if built*. Not a refactor. |
+| Abnormal-result-unacknowledged, chronic-script-expiring, diabetic-foot-exam-due, retinal-screening-due, medication-reconciliation-needed, … | **DEFERRED to PR G classification** | No corpus data and/or no code today; classifying them now would be classifying imagined code (the §D.1 anti-pattern). PR G classifies each against its then-real implementation. |
+
+**The premise-correction, stated unsoftened:** there is **no existing
+stateful follow-up logic to refactor into `OpenLoop`.** The umbrella's
+"refactor scattered existing follow-up logic" is, against the live code,
+*false* — the scattered logic is stateless cohorts (stay standing
+queries) and a write-once referral record (no transitions). `OpenLoop`'s
+value is the substrate for loops PR G will populate; its first *stateful*
+instance must be **deliberately built**, not inherited.
+
+### 2.2 F-1 FINAL — option B, LOCKED (substrate + state machine + audited actions only; first real stateful loop deferred to PR G), with the non-vacuity rider
+
+> **LOCKED at review.** The fork below was a genuine scoping decision;
+> the user locked **option B**, with the non-vacuity rider, for the same
+> reason it has been the answer six times (PR C disabled-but-built, PR D
+> one-kind-the-rest-named, PR E option 2, …): every prettier outcome is
+> reachable only by pulling another PR's work forward for *this* PR's
+> satisfaction, and the project refuses that. This is not a coincidence
+> of recommendation — it is the same anti-pattern in a new place and the
+> same cure.
+
+**Why option A is rejected (the survives-deleting-the-demo test, applied
+to PR F's would-be vertical slice).** Option A builds the
+specialist-referral-pending lifecycle "to prove the substrate end-to-end
+on a real stateful loop." Does the referral lifecycle have an
+independent reason to be built **in PR F** that survives deleting "PR F
+wants a populated/exercised state machine" from the argument? **It does
+not.** By §2.1 and umbrella locked Decision 3 the referral lifecycle is
+PR-G taxonomy work — a loop *kind* with a detector, and detectors are
+**F-4-locked as PR G**. The only thing wanting it built in PR F is PR F's
+desire to look proven on real data instead of fabricated input — exactly
+the PR-E Option-1 anti-pattern: legitimate-in-general (the referral loop
+is real PR-G work), not-for-this-reason-now (built in PR F because PR F
+wants it populated). The seventh instance, refused.
+
+**Why option B is the materially stronger outcome, not a fallback.**
+The substrate built, structurally proven on fabricated construct-validity
+input, **labelled exactly "not corpus-exercised; first real loop is PR
+G"**, with the real instance arriving in the PR that legitimately owns
+it, is brakes-before-wheel applied to the object: PR C
+disabled-but-built, PR D one-kind-the-rest-named, PR E honest-empty — a
+seventh time, and the consistency is the point. An honestly-labelled
+"built, structurally proven, not yet exercised" substrate is *more*
+trustworthy than one that looks proven because PR F reached into PR G to
+populate it.
+
+**The non-vacuity rider (LOCKED, the §D.1 cure applied to the state
+machine — load-bearing, written into §3.1/§4/§5 test scope explicitly).**
+Option B proves the state machine on fabricated input; a fabricated-input
+test passes vacuously if it only ever feeds *valid* transitions. So the
+construct-validity tests must be **proven non-vacuous by asserted
+rejection of illegal transitions** — every illegal (state, event) pair
+fed in and asserted *rejected*, not merely every legal one fed in and
+asserted accepted. The honest claim option B is permitted to make is
+**"the state machine was shown to reject what it must reject"**, never
+merely "works on well-formed fabricated input". A state machine
+"proven" only by valid fabricated transitions is the §D.1 false-green in
+a new location, and is explicitly disallowed.
+
+**The legitimate-A carve-out (recorded so the door is not falsely
+shut).** If, on **PR G's own merits**, the user later deliberately
+decides specialist-referral-pending is PR G's first loop and pulls that
+*PR-G-scope* decision forward **stated as such** — not as PR F's fix for
+wanting a populated machine — that is legitimate and routes as a
+deliberate PR-G pull-forward with its own justification (the same
+carve-out left open for PR E Option 1 / the demo workspace). **At this
+review the user did NOT make that PR-G-first-loop decision**, so F-1
+stands at B; the carve-out is a future *deliberate* PR-G decision, never
+an inference from PR F's desire to be exercised.
+
+The original fork, retained for the audit trail:
+
+- **F-1 option A — substrate + ONE honest stateful loop
+  (specialist-referral-pending), built.** PR F ships the `OpenLoop`
+  object + links + state machine + audited Open/Advance/Close/Breach
+  actions, AND builds the referral lifecycle as the *vertical slice*
+  proving the substrate end-to-end on a genuinely-stateful loop
+  (PR D's "one kind proven, not many shallow"). Heavier; produces a
+  real, exercised state machine. Risk: referral-lifecycle scope creep
+  into PR G's taxonomy.
+- **F-1 option B — substrate + state machine ONLY, zero loop
+  instance.** PR F ships `OpenLoop` + the state machine + audited
+  actions, proven by construct-validity tests on fabricated input (the
+  Phase-3 design-choice-#7 idiom: structural defence built + unit-tested,
+  labelled not-corpus-exercised), with the **first real stateful loop
+  explicitly deferred to PR G**. Lighter; the substrate is honest-but-
+  unexercised-on-real-data and *labelled exactly that* (no fake
+  populated loop). Mirrors PR C shipping the NL classifier
+  disabled-but-built.
+- **F-1 option C — defer `OpenLoop` entirely; fold it into PR G.**
+  Rejected-by-default and named: it collapses the umbrella's E→F→G→H
+  boundary and re-creates the "object declared with the taxonomy in one
+  big PR" shape the roadmap's completeness-trap warning forbids. Named
+  so the rejection is deliberate, not silent.
+
+**Recommendation (the user locks):** option B. Reasoning: option A's
+referral lifecycle is genuinely PR-G-taxonomy work; pulling it into PR F
+*because PR F wants a populated state machine* is the PR-E Option-1
+anti-pattern (legitimate-in-general, not-for-this-reason-now). Option B
+ships the substrate honestly, labelled construct-validity-only, with the
+first real loop deferred to PR G where it belongs — the
+brakes-before-wheel, vertical-slice, ship-the-proven-substrate-and-label
+-the-rest discipline applied consistently. But this is a scope call with
+real trade-offs and it is **the user's to lock**, not mine.
+
+---
+
+## 3. The `OpenLoop` object + links + state machine (conforming to F2/F3; built under the F-1 lock)
+
+**Object** `backend/ontology/objects/open_loop.py` — mirrors
+`patient.py` exactly (F2): `class OpenLoop(OntologyObject)` with
+`__object_type_name__="OpenLoop"`, `__display_template__`,
+`__fhir_resource__=None` (no clean FHIR analog — stated, not faked),
+`__pii_level__` (LOW — a loop references a patient but holds little PII
+itself; pinned at implementation against the actual fields),
+`__audited__=True`. Inherited system fields untouched. Domain props via
+`Prop(...)` with full metadata: `patient_id`
+(link_to="Patient", link_cardinality="one"),
+`opening_event_*` (what opened it — type + reference),
+`expected_closing_event_*` (what would close it),
+`loop_kind` (the taxonomy discriminator — a closed enum,
+`backend/ontology/enums/`, mirroring the consultation/document enum
+pattern), `state` (the state-machine enum, §3.1), `deadline_at`,
+`urgency`, `opened_at`, `closed_at`, `closed_reason`,
+`breached_at`. Validators (`@model_validator(mode="after")`) enforce the
+state-machine invariants declaratively (e.g. `closed_at` set iff
+`state` terminal; `breached_at` set iff `state==BREACHED`).
+
+**Links** (F3 — append `LinkType` to `LINKS`):
+`Patient --has_open_loop--> OpenLoop` (ONE_TO_MANY),
+`Consultation --opened_loop--> OpenLoop` (ONE_TO_MANY, the opening
+event), `Document --evidences_loop_closure--> OpenLoop` (MANY_TO_MANY,
+the closing evidence) — plus the matching `Prop(link_to=…)` on the
+object.
+
+### 3.1 The state machine (explicit, closed, declarative)
+
+A **closed, exhaustively-tested** transition table (F-2 LOCKED — not
+implicit string moves, no fall-through): `OPEN → AWAITING → (CLOSED |
+BREACHED)`; `BREACHED → CLOSED` (a breached loop can still be resolved
+late — an explicit tested fact, not the absence of code); `CLOSED` is
+terminal (`CLOSED → anything` is an explicit *asserted-rejected* fact,
+not merely "no code for it"). Every transition is an audited action
+(§4); no transition by a bare field write — the `model_validator`
+rejects an inconsistent (`state`, `*_at`) tuple so an un-audited
+mutation cannot produce a valid object.
+
+**F-2 + non-vacuity rider, LOCKED into the test scope (the §D.1
+mechanism, exact wording — not "construct-validity tests" but
+"construct-validity tests proven non-vacuous by asserted rejection of
+illegal transitions"):** the transition table is the single source of
+truth and its test is **exhaustive over the full state × event space**.
+For every (state, event) pair: either it is a defined transition (fed
+through the action+executor path and asserted to *execute and produce
+the expected* (state, `*_at`)) **or** it is an illegal pair (fed in and
+asserted to be **rejected** — by the transition table AND independently
+by the `model_validator`). The test must **bite**: feeding an illegal
+transition and asserting rejection is the load-bearing half; a test that
+only feeds legal transitions and asserts acceptance is the §D.1
+false-green relocated and is explicitly disallowed. Any future addition
+of a state or an event that does not update the table **fails CI**
+(the table is enumerated and the test cross-checks completeness, so an
+unhandled pair is a build failure, never a silent fall-through).
+
+---
+
+## 4. Audited actions + migration 028 (conforming to F4/F5; under the F-1 lock)
+
+**Actions** (`backend/ontology/actions/open_loop_*.py`, F4 template,
+`@register_action @dataclass(eq=False)`, registered in
+`app/actions/registered.py`): `OpenLoopOpen`, `OpenLoopAdvance`
+(OPEN→AWAITING), `OpenLoopClose`, `OpenLoopBreach`. Each:
+`preconditions()` from primitives (`ObjectExists`, `BelongsToPractice`,
+`HasStatus` on `state`, `HasPermission`), `effects()` via
+`SetMultipleFields` (state + the paired `*_at`), `to_audit_parameters()`
+/ `from_audit_parameters()`, `__reversible__=True` with **Python-side
+reversal** (`register_python_reversal`) — the `SoftDeletePatient`
+analog (single-table state change; the executor's Python reversal path,
+not an RPC, is the right weight; no multi-table atomicity needed). Loop
+mutations route **only** through `execute()` — the
+`model_validator` + the no-bare-write discipline make the audit trail
+structural, not optional.
+
+**Migration `028_open_loops.sql`** (F5): `CREATE TABLE open_loops` —
+`id uuid pk`, `workspace_id text NOT NULL` (born-scoped; TEXT, no
+::uuid — the heterogeneous-id postmortem scar), `patient_id`,
+`loop_kind`, `state`, `opening_*`, `expected_closing_*`, `deadline_at`,
+`urgency`, `opened_at`, `closed_at`, `closed_reason`, `breached_at`,
+`created_at/updated_at/deleted_at`; indexes on `(workspace_id, state)`
+and `(workspace_id, patient_id)`; **RLS-deny-all, migration-018 idiom
+verbatim** (ENABLE RLS, no policy, NOT FORCE, NOT auth.*); **added to
+`test_tenant_query_isolation.py` `TENANT_TABLES`** (born-scoped → zero
+new BASELINE keys); **explicit NOTIFY-pgrst decided-inclusion** header
+per the `027` reasoning (table, no function). Header carries the
+single-table scope + the 018-idiom rationale so a future maintainer
+inherits it.
+
+---
+
+## 5. Tests / verification
+
+- **State-machine non-vacuity — LOCKED test scope (F-1 rider, the §D.1
+  mechanism, exact wording):** these are not merely "construct-validity
+  tests" — they are **construct-validity tests proven non-vacuous by
+  asserted rejection of illegal transitions**. The test is **exhaustive
+  over the full state × event space**: every legal pair fed through the
+  action+executor path and asserted to execute + produce the expected
+  (state, `*_at`); every **illegal** pair fed in and asserted
+  **rejected** — by the transition table AND independently by the
+  `model_validator`. The illegal-rejection half is load-bearing; a suite
+  that only feeds legal fabricated transitions is the §D.1 false-green
+  relocated and **fails review**. CI completeness check: an unhandled
+  (state, event) pair (e.g. a future-added state/event not in the table)
+  is a **build failure**, never a silent fall-through. `CLOSED → *` and
+  the `BREACHED → CLOSED` allowance are explicit asserted facts in the
+  table test, not the absence of code.
+- **Audited-action round-trip**: open → advance → close through
+  `execute()`; assert one `action_audit_log` row per transition with
+  correct `affected_objects`/`outcome`; reverse the close; assert
+  `reversed_by_audit_id`/`reverses_audit_id` wiring and state restored
+  (the `test_action_reversal` idiom).
+- **Tenant ratchet**: `test_no_new_unscoped_tenant_queries` stays green
+  with `open_loops` added to `TENANT_TABLES` (zero new BASELINE keys).
+- **RLS**: `open_loops` `relrowsecurity=true`, 0 permissive policies
+  (the 027 RUN_INTEGRATION idiom).
+- **Under F-1 option B**: the substrate is exercised on **fabricated**
+  loop input only, and every such test is **named and labelled
+  construct-validity-only** (design-choice-#7 idiom) — no fabricated
+  loop is presented as corpus evidence; the "first real stateful loop is
+  PR G" deferral is recorded, not hidden.
+
+### §5.1 §D.1-class inherited-knowledge note — the `action_audit_log` close↔reversal FK cycle (recorded so it is NOT re-derived the hard way in a live DB)
+
+> Same register as §2.0 / the post-mortem's §D·§D.1: a piece of
+> schema knowledge surfaced by an actual failure, written into the
+> record so the next person inherits it instead of rediscovering it.
+
+The RUN_INTEGRATION round-trip
+(`tests/test_open_loop_executor_roundtrip.py`) on its **first** run
+**failed in the test's teardown, not in the round-trip.** The round-trip
+itself was correct and independently corroborated by the live
+`action_audit_log` (the `OpenLoopClose success` ↔ `ReverseOpenLoopClose
+reversed` pair, wired both ways, persisted as fact regardless of the
+test's pass/fail). The teardown's naive parent-before-child
+`DELETE FROM action_audit_log` hit
+`ForeignKeyViolation: action_audit_log_reverses_audit_id_fkey` and left
+**2 orphaned audit rows in the live demo workspace** — treated as a real
+harm (audit-log pollution in a clinical system's source-of-truth table
+is exactly the failure that table exists to prevent), reported before
+interpretation, cleaned FK-correct scoped to the two known ids, verified
+zero residue by read-back, the teardown then permanently fixed and the
+run re-done clean.
+
+**The inherited knowledge (the load-bearing part):** a reversal and its
+target in `action_audit_log` form a **deliberate bidirectional FK
+cycle** — the reversal row's `reverses_audit_id` → the original, and the
+original's `reversed_by_audit_id` → the reversal. **This cycle is
+correct production design** (it is what makes a reversal and its target
+mutually discoverable; do not "fix" it). The consequence for **any**
+future teardown, cleanup, maintenance, or migration that deletes across
+a reversal pair: a naive ordered delete **cannot** break the cycle and
+**will** `ForeignKeyViolation`. **The cycle-safe idiom (established
+here, reuse it):** first `UPDATE action_audit_log SET
+reverses_audit_id=NULL, reversed_by_audit_id=NULL WHERE id = <each
+collected id>` for *every* row in the set, **then** `DELETE` them —
+order- and cycle-independent. Any code touching audit reversal rows
+without this will hit the exact wall this run hit; this note is so it is
+inherited, not re-derived in a live DB. (PR G builds detectors that
+write/clean audit rows — this is directly its inheritance; see
+[[project-phase4-pr-f-lock-and-pr-g-inheritance]].)
+
+---
+
+## 6. Decisions locked at review — F-1, F-2, F-3, F-4 FINAL
+
+Recorded as the user locked them; the reasoning is the lock and is
+recorded so it can be overridden deliberately, not re-derived. No
+umbrella decision re-opened.
+
+**F-1 — FINAL: option B + the non-vacuity rider (§2.0, §2.2, §3.1, §5).**
+Substrate + state machine + audited actions only; first real stateful
+loop deferred to PR G. Option A REJECTED (the survives-deleting-the-demo
+test: the referral lifecycle has no independent reason to be built *in
+PR F* — it is PR-G taxonomy work pulled forward for PR F's
+populated-machine satisfaction, the PR-E Option-1 anti-pattern, seventh
+instance, refused). Option C REJECTED (collapses the E→F→G→H boundary,
+the completeness-trap). **Non-vacuity rider LOCKED**: the
+construct-validity tests are *"proven non-vacuous by asserted rejection
+of illegal transitions, the §D.1 mechanism"* — written verbatim into the
+§3.1/§5 test scope; a suite that only feeds legal fabricated transitions
+fails review. **Legitimate-A carve-out**: only a future *deliberate
+PR-G-scope* decision (specialist-referral-pending chosen as PR G's first
+loop on PR G's merits, stated as such) — never an inference from PR F's
+desire to be exercised; the user did NOT make that decision at this
+review, so F-1 stands at B.
+
+**F-2 — FINAL: `OPEN → AWAITING → (CLOSED | BREACHED)`, `BREACHED →
+CLOSED`, `CLOSED` terminal — closed, exhaustively-tested transition
+table.** Rider LOCKED: every (state, event) pair is a defined transition
+**or** an asserted-rejected illegal one; **no implicit fall-through**;
+the table is enumerated and the test cross-checks completeness so a
+future-added state/event not in the table **fails CI**; `BREACHED →
+CLOSED` and `CLOSED → *`-rejected are explicit tested facts, not the
+absence of code. Every transition an audited action; no bare field
+write valid (`model_validator` enforced).
+
+**F-3 — FINAL: PR F defines the `loop_kind` enum *type* but seeds only
+honestly-backed kinds; the rest are named-not-built (PR-D Decision-2
+discipline applied to the enum).** An enum value with no detector and no
+honest instance is a fake-property (asserts a capability the code lacks)
+— forbidden. Under option B the enum carries the structural minimum for
+substrate coherence; `specialist_referral_pending` is the **named**
+first member, **not instantiated** until PR G builds its detector;
+extensibility is **structural** (PR G adds kinds without migration
+churn). The plan states which kinds are *defined* vs *deferred-and-named*
+so a future reader sees the boundary, not a half-populated enum of
+uncertain status.
+
+**F-4 — FINAL: detectors are PR G, not PR F (mechanism-vs-policy cut).**
+PR F ships the *mechanism* — the object, state machine, and audited
+Open/Advance/Close/Breach actions by which a loop is mutated. PR G ships
+the *policy* — what *decides* to open a loop from a clinical event (the
+detectors), riding the §F5 `@app.on_event` worker host alongside the
+taxonomy. A detector in PR F would be the referral-lifecycle
+anti-pattern again (PR-G work pulled forward for PR F's satisfaction).
+
+---
+
+## What PR F earns when it lands
+
+`OpenLoop` exists as the fourth ontology object — same declarative
+template as Patient/Document/Consultation — with a closed, explicitly-
+tested state machine and audited, reversible transitions through the
+existing executor; `open_loops` is RLS-deny-all and born tenant-scoped
+(zero ratchet cost). What PR F **does not** claim, stated unsoftened
+(the §D.1/§E discipline): it does **not** "refactor existing follow-up
+logic" — the live code has none that is stateful; the stateless cohorts
+remain standing queries by locked Decision 3, and PR F says so rather
+than inventing a lifecycle to look like a refactor. Under **locked F-1
+option B** the substrate is **built and proven non-vacuous by asserted
+rejection of illegal transitions (the §D.1 mechanism), but not
+corpus-exercised** — labelled exactly that, with the first real stateful
+loop deferred to PR G where the taxonomy and its detectors live. The
+honest claim PR F makes is "the state machine was shown to reject what
+it must reject", never "exercised on a real loop". The
+premise-correction (no existing stateful logic) was caught at plan time
+by verifying the umbrella's wording against the code, not discovered
+mid-implementation — the method working at the boundary it was built
+for, a seventh time.

--- a/backend/app/actions/registered.py
+++ b/backend/app/actions/registered.py
@@ -33,3 +33,10 @@ from ontology.actions import reassign_document      # noqa: F401
 from ontology.actions import merge_patient          # noqa: F401
 # from ontology.actions import reassign_document     # noqa: F401
 # from ontology.actions import merge_patient         # noqa: F401
+
+# Phase 4 PR F — OpenLoop substrate (F-1=B: substrate + state machine +
+# audited mutation actions only; no detector, no real instance — PR G).
+from ontology.actions import open_loop_open         # noqa: F401
+from ontology.actions import open_loop_advance      # noqa: F401
+from ontology.actions import open_loop_breach       # noqa: F401
+from ontology.actions import open_loop_close        # noqa: F401

--- a/backend/migrations/028_open_loops.sql
+++ b/backend/migrations/028_open_loops.sql
@@ -1,0 +1,121 @@
+-- ============================================================================
+-- Migration 028 — open_loops (Phase 4 PR F: the OpenLoop substrate)
+-- ============================================================================
+--
+-- The persistence target for the fourth ontology object, `OpenLoop`
+-- (ontology/objects/open_loop.py). A row is one tracked clinical loop:
+-- an opening event, an expected closing event, a deadline, an urgency,
+-- and a lifecycle state (the closed transition table in
+-- ontology/objects/open_loop_state.py: OPEN → AWAITING → (CLOSED |
+-- BREACHED), BREACHED → CLOSED, CLOSED terminal).
+--
+-- SCOPE — F-1 = option B (LOCKED): this is the SUBSTRATE ONLY. PR F adds
+-- the table, the object, the state machine, and the audited mutation
+-- actions. It does NOT add a detector (F-4: detectors are PR G) and does
+-- NOT instantiate any real loop. The substrate ships built and proven
+-- non-vacuous on fabricated input, the first real stateful loop deferred
+-- to PR G. This migration creates storage; it asserts nothing about a
+-- loop existing.
+--
+-- COLUMNS — grounded in the REAL OpenLoop field set (open_loop.py), not
+-- guessed. loop_kind / state / urgency are TEXT, deliberately NOT a DB
+-- ENUM type: F-3 (locked) — the taxonomy is PR G's and extensibility
+-- must be structural (PR G adds an enum member, NO migration churn). The
+-- (state, *_at) consistency invariant is enforced at the ontology layer
+-- (OpenLoop.model_validator, the independent second guard) and the
+-- audited-action path is the only writer; the table is storage, the
+-- ontology is the guard — the base.py "ontology sits above persistence"
+-- principle. A DB CHECK is deliberately NOT added (it is not in PR F's
+-- locked scope; the guard is the model_validator + the executor path).
+--
+-- IDEMPOTENCY: CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS;
+-- a double-run is a clean no-op. No data is seeded (substrate only).
+--
+-- TENANT SCOPE: workspace_id is TEXT and joins workspaces.id (TEXT) with
+-- NO ::uuid cast (the heterogeneous-identifier postmortem scar; the
+-- ontology object's `practice_id` is the slug-shaped tenancy ref and
+-- maps to this column — the established Patient split). Added to the
+-- PR 5 static tenant-guard TENANT_TABLES; under F-1=B the audited Effect
+-- primitives use `.table(self.table)` (a variable, not a string
+-- literal) so the static scanner finds ZERO `.table("open_loops")`
+-- literal chains — adding it to TENANT_TABLES adds ZERO new BASELINE
+-- keys (born tenant-scoped; the ratchet only goes down). Proven by
+-- running test_no_new_unscoped_tenant_queries, not asserted.
+--
+-- RLS — DENY-ALL, the migration-018 idiom VERBATIM:
+--   ENABLE ROW LEVEL SECURITY with NO permissive policy => deny-all to
+--   non-bypass roles. service_role backend (rolbypassrls=TRUE) and the
+--   postgres migration role are unaffected; anon/authenticated get ZERO
+--   rows. We deliberately do NOT use FORCE ROW LEVEL SECURITY (018:36
+--   rationale) and do NOT add auth.*-keyed policies (018:43-48 — the app
+--   does not use Supabase Auth). This reproduces exactly the posture
+--   migration 018 gave the existing tenant tables and 027 gave
+--   briefing_items.
+--
+-- POSTGREST SCHEMA-CACHE — `NOTIFY pgrst` is INCLUDED, a consciously-
+-- decided call (the discipline of 025 omitting it because it added no
+-- function, 026 including it because it added functions, 027 including
+-- it for a REST-builder-addressed table). 028 adds a TABLE and no
+-- function. Reasoning for INCLUDING (same as 027): open_loops is
+-- addressed by the supabase-py REST/table builder
+-- (.table("open_loops")) via the audited Effect primitives; a stale
+-- PostgREST table-schema cache could 404 early .table("open_loops")
+-- calls until the cache happens to reload. NOTIFY is the cheap correct
+-- hygiene here even though no function is added — a decided inclusion,
+-- NOT a cargo-cult of 026's function-driven NOTIFY and NOT a cargo-cult
+-- of 025's omission.
+--
+-- ORDERING: strictly after 027. Adds no function, so no
+-- template-availability race; standard deploy sequence.
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.open_loops (
+    id                          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- tenancy (DB-level; the object's practice_id maps here)
+    workspace_id                TEXT        NOT NULL,
+    -- the patient this loop concerns
+    patient_id                  UUID        NOT NULL,
+    -- taxonomy discriminator (TEXT, not enum — F-3 structural extensibility)
+    loop_kind                   TEXT        NOT NULL,
+    -- lifecycle state (the closed transition table is the source of truth)
+    state                       TEXT        NOT NULL,
+    -- what opened it (PR F substrate: 'manual'; PR G detectors set more)
+    opening_event_kind          TEXT        NOT NULL,
+    opening_event_ref           TEXT,
+    -- human-readable description of the event that would close it
+    expected_closing_event_kind TEXT        NOT NULL,
+    -- urgency (TEXT, not enum — same F-3 rationale as loop_kind)
+    urgency                     TEXT        NOT NULL DEFAULT 'routine',
+    -- when it breaches if not closed (nullable: a loop may have none)
+    deadline_at                 TIMESTAMPTZ,
+    -- lifecycle timestamps (consistency enforced by the ontology guard)
+    opened_at                   TIMESTAMPTZ NOT NULL,
+    closed_at                   TIMESTAMPTZ,
+    closed_reason               TEXT,
+    breached_at                 TIMESTAMPTZ,
+    -- ontology system fields
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at                  TIMESTAMPTZ
+);
+
+-- Workspace-scoped reads by state (the briefing/PR-G read shape) and by
+-- patient (the Patient--has_open_loop-->OpenLoop traversal).
+CREATE INDEX IF NOT EXISTS idx_open_loops_workspace_state
+    ON public.open_loops (workspace_id, state);
+CREATE INDEX IF NOT EXISTS idx_open_loops_workspace_patient
+    ON public.open_loops (workspace_id, patient_id);
+
+-- RLS deny-all — migration-018 idiom verbatim. Enable RLS, add NO
+-- permissive policy. NOT FORCE. NOT auth.*-keyed.
+ALTER TABLE public.open_loops ENABLE ROW LEVEL SECURITY;
+
+-- Phase-0 finding discipline — consciously INCLUDED for 028 (see header:
+-- open_loops is REST-builder-addressed via the audited Effect
+-- primitives; a stale table-schema cache could 404 early .table()
+-- calls). Decided inclusion, not cargo-cult.
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/backend/ontology/__init__.py
+++ b/backend/ontology/__init__.py
@@ -34,8 +34,15 @@ from ontology.enums.consultation_enums import (
     EncounterType,
 )
 from ontology.enums.document_enums import DocumentSource, DocumentStatus
+from ontology.enums.open_loop_enums import (
+    LoopKind,
+    LoopUrgency,
+    OpenLoopEvent,
+    OpenLoopState,
+)
 from ontology.objects.consultation import Consultation
 from ontology.objects.document import Document
+from ontology.objects.open_loop import OpenLoop
 from ontology.objects.patient import Patient
 
 __all__ = [
@@ -52,4 +59,9 @@ __all__ = [
     "ConsultationStatus",
     "EncounterSetting",
     "EncounterType",
+    "OpenLoop",
+    "OpenLoopState",
+    "OpenLoopEvent",
+    "LoopKind",
+    "LoopUrgency",
 ]

--- a/backend/ontology/actions/_open_loop_transition.py
+++ b/backend/ontology/actions/_open_loop_transition.py
@@ -1,0 +1,281 @@
+"""
+Shared effects + reversal for the OpenLoop audited actions (Phase 4
+PR F). Mirrors the SoftDeletePatient analog (single-table mutation,
+Python-side reversal) and uses ONLY the verified Effect/EffectResult
+shape (app/actions/base.py) and the verified primitive structure
+(app/actions/primitives.py SetField.apply).
+
+THE STATE MACHINE IS THE SOURCE OF TRUTH. `LoopTransitionEffect` does
+not hardcode target states: it reads the loop's current state and calls
+`apply_transition` (the closed table proven non-vacuous before this
+code existed). The action's precondition already gates the legal source
+state; this effect calling `apply_transition` is the SECOND structural
+guard at the mutation layer — an illegal transition that somehow reached
+here fails the effect, it does not silently write.
+
+REVERSAL is a before-image undo: the effect records the exact prior
+values of every field it changes into EffectResult.detail (JSON); the
+reversal builder reads it back from `original["effects_applied"]` (the
+verified audit-row shape — executor loads the row via select("*"), and
+effects_applied[i]["result"] is EffectResult.to_dict()) and restores
+those literal prior values. This is correct regardless of which legal
+path produced the state (e.g. AWAITING→CLOSED vs BREACHED→CLOSED both
+reverse to their literal recorded prior), the SoftDeletePatient
+inverse-effect pattern generalised.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.actions.base import (
+    ERROR_CODE_EFFECT_FAILED,
+    EffectDescriptor,
+    EffectResult,
+    ErrorDetail,
+    ExecutorContext,
+)
+from ontology.enums.open_loop_enums import OpenLoopEvent, OpenLoopState
+from ontology.objects.open_loop_state import IllegalLoopTransition, apply_transition
+
+_TABLE = "open_loops"
+_OBJ = "OpenLoop"
+
+# Which timestamp field each event sets, alongside `state` + `updated_at`.
+# CLOSE additionally sets closed_reason (from the action parameter).
+_EVENT_TS_FIELD = {
+    OpenLoopEvent.ADVANCE: None,
+    OpenLoopEvent.BREACH: "breached_at",
+    OpenLoopEvent.CLOSE: "closed_at",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class LoopTransitionEffect:
+    """Apply one OpenLoop transition via the closed table. Records the
+    before-image for reversal. Mirrors SetField.apply structure."""
+
+    loop_id: str
+    event: OpenLoopEvent
+    closed_reason: Optional[str] = None  # only meaningful for CLOSE
+    name: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            self.name = f"LoopTransition({self.event.value})"
+
+    def _read_row(self, ctx: ExecutorContext) -> Optional[Dict[str, Any]]:
+        res = (
+            ctx.supabase.table(_TABLE)
+            .select("state,closed_at,closed_reason,breached_at,updated_at")
+            .eq("id", self.loop_id)
+            .execute()
+        )
+        data = getattr(res, "data", None) or []
+        return data[0] if data else None
+
+    def plan(self, ctx: ExecutorContext) -> EffectDescriptor:
+        return EffectDescriptor(
+            name=self.name,
+            summary=f"would apply {self.event.value} to open_loop {self.loop_id}",
+            will_affect=[{"type": _OBJ, "id": self.loop_id, "op": "updated"}],
+        )
+
+    def apply(self, ctx: ExecutorContext) -> EffectResult:
+        try:
+            row = self._read_row(ctx)
+            if row is None:
+                raise ValueError(f"no open_loops row with id={self.loop_id}")
+
+            current = OpenLoopState(row["state"])
+            # SECOND structural guard: the closed table, again, at the
+            # mutation layer. Raises IllegalLoopTransition if somehow
+            # illegal (the precondition should have caught it first).
+            new_state = apply_transition(current, self.event)
+
+            ts_field = _EVENT_TS_FIELD[self.event]
+            now = _now_iso()
+            updates: Dict[str, Any] = {"state": new_state.value, "updated_at": now}
+            if ts_field is not None:
+                updates[ts_field] = now
+            if self.event is OpenLoopEvent.CLOSE:
+                updates["closed_reason"] = self.closed_reason
+
+            # before-image of EXACTLY the fields we are about to change
+            before = {k: row.get(k) for k in updates}
+
+            (
+                ctx.supabase.table(_TABLE)
+                .update(updates)
+                .eq("id", self.loop_id)
+                .execute()
+            )
+            ctx.append_affected_object(
+                object_type=_OBJ, object_id=self.loop_id, op="updated"
+            )
+            return EffectResult(
+                name=self.name,
+                succeeded=True,
+                affected=[{"type": _OBJ, "id": self.loop_id, "op": "updated"}],
+                detail=json.dumps({"loop_id": self.loop_id, "before": before}),
+            )
+        except IllegalLoopTransition as exc:
+            return EffectResult(
+                name=self.name,
+                succeeded=False,
+                error=ErrorDetail(
+                    code=ERROR_CODE_EFFECT_FAILED,
+                    message=str(exc),
+                    context={"table": _TABLE, "object_id": self.loop_id},
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return EffectResult(
+                name=self.name,
+                succeeded=False,
+                error=ErrorDetail(
+                    code=ERROR_CODE_EFFECT_FAILED,
+                    message=f"failed to apply {self.event.value}: {exc}",
+                    context={"table": _TABLE, "object_id": self.loop_id},
+                ),
+            )
+
+
+@dataclass
+class RestoreLoopFields:
+    """Inverse effect: write a literal before-image back. Mirrors
+    SetField.apply structure (multi-column update by id)."""
+
+    loop_id: str
+    before: Dict[str, Any]
+    name: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            self.name = f"RestoreLoopFields({self.loop_id[:8]}...)"
+
+    def plan(self, ctx: ExecutorContext) -> EffectDescriptor:
+        return EffectDescriptor(
+            name=self.name,
+            summary=f"would restore {sorted(self.before)} on open_loop {self.loop_id}",
+            will_affect=[{"type": _OBJ, "id": self.loop_id, "op": "updated"}],
+        )
+
+    def apply(self, ctx: ExecutorContext) -> EffectResult:
+        try:
+            (
+                ctx.supabase.table(_TABLE)
+                .update(self.before)
+                .eq("id", self.loop_id)
+                .execute()
+            )
+            ctx.append_affected_object(
+                object_type=_OBJ, object_id=self.loop_id, op="updated"
+            )
+            return EffectResult(
+                name=self.name,
+                succeeded=True,
+                affected=[{"type": _OBJ, "id": self.loop_id, "op": "updated"}],
+            )
+        except Exception as exc:  # noqa: BLE001
+            return EffectResult(
+                name=self.name,
+                succeeded=False,
+                error=ErrorDetail(
+                    code=ERROR_CODE_EFFECT_FAILED,
+                    message=f"failed to restore open_loop {self.loop_id}: {exc}",
+                    context={"table": _TABLE, "object_id": self.loop_id},
+                ),
+            )
+
+
+@dataclass
+class CreateLoopEffect:
+    """Insert a new OpenLoop row, born OPEN. Mirrors SetField.apply
+    structure (single-table write by the executor's supabase client).
+    Records the created id for the Open reversal (soft-delete)."""
+
+    loop_id: str
+    row: Dict[str, Any]
+    name: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            self.name = f"CreateLoop({self.loop_id[:8]}...)"
+
+    def plan(self, ctx: ExecutorContext) -> EffectDescriptor:
+        return EffectDescriptor(
+            name=self.name,
+            summary=f"would create open_loop {self.loop_id} (state=open)",
+            will_affect=[{"type": _OBJ, "id": self.loop_id, "op": "created"}],
+        )
+
+    def apply(self, ctx: ExecutorContext) -> EffectResult:
+        try:
+            ctx.supabase.table(_TABLE).insert(self.row).execute()
+            ctx.append_affected_object(
+                object_type=_OBJ, object_id=self.loop_id, op="created"
+            )
+            return EffectResult(
+                name=self.name,
+                succeeded=True,
+                affected=[{"type": _OBJ, "id": self.loop_id, "op": "created"}],
+                detail=json.dumps({"loop_id": self.loop_id, "created": True}),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return EffectResult(
+                name=self.name,
+                succeeded=False,
+                error=ErrorDetail(
+                    code=ERROR_CODE_EFFECT_FAILED,
+                    message=f"failed to create open_loop {self.loop_id}: {exc}",
+                    context={"table": _TABLE, "object_id": self.loop_id},
+                ),
+            )
+
+
+def loop_open_reversal(original: Dict[str, Any], actor) -> List[Any]:
+    """Reverse of OpenLoopOpen: soft-delete the created loop. Reads the
+    created id from the recorded EffectResult.detail; uses the verified
+    SoftDelete primitive (the SoftDeletePatient inverse pattern)."""
+    from app.actions.primitives import SoftDelete
+
+    for entry in original.get("effects_applied", []) or []:
+        result = (entry or {}).get("result") or {}
+        detail = result.get("detail")
+        if not detail:
+            continue
+        try:
+            payload = json.loads(detail)
+        except (TypeError, ValueError):
+            continue
+        if payload.get("created") and "loop_id" in payload:
+            return [SoftDelete(_TABLE, payload["loop_id"], object_type=_OBJ)]
+    return []
+
+
+def loop_transition_reversal(original: Dict[str, Any], actor) -> List[Any]:
+    """Build the inverse from the recorded before-image. Reads the
+    verified audit-row shape: original['effects_applied'][i]['result']
+    is EffectResult.to_dict(); detail carries {'loop_id','before'}."""
+    for entry in original.get("effects_applied", []) or []:
+        result = (entry or {}).get("result") or {}
+        detail = result.get("detail")
+        if not detail:
+            continue
+        try:
+            payload = json.loads(detail)
+        except (TypeError, ValueError):
+            continue
+        if "loop_id" in payload and "before" in payload:
+            return [RestoreLoopFields(payload["loop_id"], payload["before"])]
+    # No recorded before-image → nothing to reverse (idempotent no-op),
+    # the same posture as a missing-row reversal.
+    return []

--- a/backend/ontology/actions/open_loop_advance.py
+++ b/backend/ontology/actions/open_loop_advance.py
@@ -1,0 +1,81 @@
+"""
+OpenLoopAdvance — OPEN → AWAITING. Phase 4 PR F.
+
+Mirrors SoftDeletePatient (single-table mutation, @register_action,
+Python reversal). The HasStatus precondition pins the legal source
+state; the effect calls the closed transition table (the SECOND
+structural guard). Reversal restores the recorded before-image.
+Authorization deferred to PR G (F-4) — see open_loop_open.py docstring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from app.actions.base import Action, Effect, Precondition
+from app.actions.executor import register_python_reversal
+from app.actions.primitives import BelongsToPractice, HasStatus, NotSoftDeleted, ObjectExists
+from app.actions.registry import register_action
+from ontology.actions._open_loop_transition import (
+    LoopTransitionEffect,
+    loop_transition_reversal,
+)
+from ontology.enums.open_loop_enums import OpenLoopEvent, OpenLoopState
+
+
+@register_action
+@dataclass(eq=False)
+class OpenLoopAdvance(Action):
+    """Advance a loop OPEN → AWAITING (its expected closing event is now
+    pending; the deadline is live). Reversible."""
+
+    __action_name__: str = "OpenLoopAdvance"
+    __action_version__: int = 1
+    __reversible__: bool = True
+    __pii_level__: str = "low"
+
+    loop_id: str = ""
+    actor_user_id: str = ""
+    actor_email: Optional[str] = None
+    practice_id: str = ""
+    workspace_id: str = ""
+
+    def preconditions(self) -> List[Precondition]:
+        return [
+            ObjectExists("open_loops", self.loop_id),
+            BelongsToPractice("open_loops", self.loop_id, self.workspace_id),
+            NotSoftDeleted("open_loops", self.loop_id),
+            HasStatus(
+                table="open_loops",
+                object_id=self.loop_id,
+                expected_status=OpenLoopState.OPEN.value,
+                column="state",
+            ),
+        ]
+
+    def effects(self) -> List[Effect]:
+        return [LoopTransitionEffect(self.loop_id, OpenLoopEvent.ADVANCE)]
+
+    def describe_for_user(self) -> str:
+        return f"Advance loop {self.loop_id} (OPEN → AWAITING). Reversible."
+
+    def to_audit_parameters(self) -> Dict[str, Any]:
+        return {
+            "loop_id": self.loop_id,
+            "actor_user_id": self.actor_user_id,
+            "practice_id": self.practice_id,
+            "workspace_id": self.workspace_id,
+        }
+
+    @classmethod
+    def from_audit_parameters(cls, params: Dict[str, Any]) -> "OpenLoopAdvance":
+        return cls(
+            loop_id=params["loop_id"],
+            actor_user_id=params.get("actor_user_id", ""),
+            practice_id=params.get("practice_id", ""),
+            workspace_id=params.get("workspace_id", ""),
+        )
+
+
+register_python_reversal("OpenLoopAdvance", loop_transition_reversal)

--- a/backend/ontology/actions/open_loop_breach.py
+++ b/backend/ontology/actions/open_loop_breach.py
@@ -1,0 +1,81 @@
+"""
+OpenLoopBreach — AWAITING → BREACHED. Phase 4 PR F.
+
+Mirrors SoftDeletePatient. HasStatus pins the legal source (AWAITING);
+the effect calls the closed table (second guard) and sets breached_at.
+Reversal restores the before-image (BREACHED → AWAITING, breached_at
+cleared to its recorded prior). Authorization deferred to PR G (F-4).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from app.actions.base import Action, Effect, Precondition
+from app.actions.executor import register_python_reversal
+from app.actions.primitives import BelongsToPractice, HasStatus, NotSoftDeleted, ObjectExists
+from app.actions.registry import register_action
+from ontology.actions._open_loop_transition import (
+    LoopTransitionEffect,
+    loop_transition_reversal,
+)
+from ontology.enums.open_loop_enums import OpenLoopEvent, OpenLoopState
+
+
+@register_action
+@dataclass(eq=False)
+class OpenLoopBreach(Action):
+    """Breach a loop AWAITING → BREACHED (the deadline passed without the
+    closing event). NOT terminal — a breached loop can still be closed
+    late. Reversible."""
+
+    __action_name__: str = "OpenLoopBreach"
+    __action_version__: int = 1
+    __reversible__: bool = True
+    __pii_level__: str = "low"
+
+    loop_id: str = ""
+    actor_user_id: str = ""
+    actor_email: Optional[str] = None
+    practice_id: str = ""
+    workspace_id: str = ""
+
+    def preconditions(self) -> List[Precondition]:
+        return [
+            ObjectExists("open_loops", self.loop_id),
+            BelongsToPractice("open_loops", self.loop_id, self.workspace_id),
+            NotSoftDeleted("open_loops", self.loop_id),
+            HasStatus(
+                table="open_loops",
+                object_id=self.loop_id,
+                expected_status=OpenLoopState.AWAITING.value,
+                column="state",
+            ),
+        ]
+
+    def effects(self) -> List[Effect]:
+        return [LoopTransitionEffect(self.loop_id, OpenLoopEvent.BREACH)]
+
+    def describe_for_user(self) -> str:
+        return f"Breach loop {self.loop_id} (AWAITING → BREACHED). Reversible."
+
+    def to_audit_parameters(self) -> Dict[str, Any]:
+        return {
+            "loop_id": self.loop_id,
+            "actor_user_id": self.actor_user_id,
+            "practice_id": self.practice_id,
+            "workspace_id": self.workspace_id,
+        }
+
+    @classmethod
+    def from_audit_parameters(cls, params: Dict[str, Any]) -> "OpenLoopBreach":
+        return cls(
+            loop_id=params["loop_id"],
+            actor_user_id=params.get("actor_user_id", ""),
+            practice_id=params.get("practice_id", ""),
+            workspace_id=params.get("workspace_id", ""),
+        )
+
+
+register_python_reversal("OpenLoopBreach", loop_transition_reversal)

--- a/backend/ontology/actions/open_loop_close.py
+++ b/backend/ontology/actions/open_loop_close.py
@@ -1,0 +1,102 @@
+"""
+OpenLoopClose — (AWAITING | BREACHED) → CLOSED. Phase 4 PR F.
+
+Mirrors SoftDeletePatient. CLOSE is legal from TWO source states, so the
+precondition is StatusOneOf (the verified multi-state primitive), not
+HasStatus. The effect calls the closed table (second guard) and sets
+closed_at + closed_reason. Reversal restores the before-image — correct
+regardless of which path (AWAITING→CLOSED vs BREACHED→CLOSED) because it
+restores the literal recorded prior values. Authorization deferred to
+PR G (F-4).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from app.actions.base import Action, Effect, Precondition
+from app.actions.executor import register_python_reversal
+from app.actions.primitives import (
+    BelongsToPractice,
+    NotSoftDeleted,
+    ObjectExists,
+    StatusOneOf,
+)
+from app.actions.registry import register_action
+from ontology.actions._open_loop_transition import (
+    LoopTransitionEffect,
+    loop_transition_reversal,
+)
+from ontology.enums.open_loop_enums import OpenLoopEvent, OpenLoopState
+
+
+@register_action
+@dataclass(eq=False)
+class OpenLoopClose(Action):
+    """Close a loop (AWAITING | BREACHED) → CLOSED (terminal). A breached
+    loop closed here is a legitimate late resolution. Reversible (to its
+    recorded prior state — AWAITING or BREACHED — exactly)."""
+
+    __action_name__: str = "OpenLoopClose"
+    __action_version__: int = 1
+    __reversible__: bool = True
+    __pii_level__: str = "low"
+
+    loop_id: str = ""
+    closed_reason: str = ""
+    actor_user_id: str = ""
+    actor_email: Optional[str] = None
+    practice_id: str = ""
+    workspace_id: str = ""
+
+    def preconditions(self) -> List[Precondition]:
+        return [
+            ObjectExists("open_loops", self.loop_id),
+            BelongsToPractice("open_loops", self.loop_id, self.workspace_id),
+            NotSoftDeleted("open_loops", self.loop_id),
+            StatusOneOf(
+                table="open_loops",
+                object_id=self.loop_id,
+                allowed=[
+                    OpenLoopState.AWAITING.value,
+                    OpenLoopState.BREACHED.value,
+                ],
+                column="state",
+            ),
+        ]
+
+    def effects(self) -> List[Effect]:
+        return [
+            LoopTransitionEffect(
+                self.loop_id, OpenLoopEvent.CLOSE, closed_reason=self.closed_reason
+            )
+        ]
+
+    def describe_for_user(self) -> str:
+        return (
+            f"Close loop {self.loop_id} (→ CLOSED, reason: "
+            f"{self.closed_reason!r}). Reversible."
+        )
+
+    def to_audit_parameters(self) -> Dict[str, Any]:
+        return {
+            "loop_id": self.loop_id,
+            "closed_reason": self.closed_reason,
+            "actor_user_id": self.actor_user_id,
+            "practice_id": self.practice_id,
+            "workspace_id": self.workspace_id,
+        }
+
+    @classmethod
+    def from_audit_parameters(cls, params: Dict[str, Any]) -> "OpenLoopClose":
+        return cls(
+            loop_id=params["loop_id"],
+            closed_reason=params.get("closed_reason", ""),
+            actor_user_id=params.get("actor_user_id", ""),
+            practice_id=params.get("practice_id", ""),
+            workspace_id=params.get("workspace_id", ""),
+        )
+
+
+register_python_reversal("OpenLoopClose", loop_transition_reversal)

--- a/backend/ontology/actions/open_loop_open.py
+++ b/backend/ontology/actions/open_loop_open.py
@@ -1,0 +1,131 @@
+"""
+OpenLoopOpen — open a tracked clinical loop (born OPEN). Phase 4 PR F.
+
+Mirrors the SoftDeletePatient analog (single-table mutation,
+@register_action, Python-side reversal). Reversal soft-deletes the
+created loop (the SoftDeletePatient inverse pattern, applied to a
+create).
+
+AUTHORIZATION DEFERRED TO PR G (F-4, mechanism-vs-policy cut — recorded,
+not skipped): this action is the *mechanism* by which a loop is opened.
+*Who* may open one — the capability gate — belongs with the *policy*
+layer (the PR-G detector/endpoint that invokes it). PR F deliberately
+does NOT attach a guessed `HasPermission(...)`: minting/guessing a
+capability string here would be a fake-property (a gate that doesn't
+match any real entitlement). The structural preconditions (the patient
+exists and belongs to the workspace) ARE enforced; the authorization
+precondition is a named PR-G addition, not a silent omission. F-1=B:
+substrate only, no detector, no real instance — proven non-vacuous on
+fabricated input, first real loop is PR G's.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from app.actions.base import Action, Effect, Precondition
+from app.actions.executor import register_python_reversal
+from app.actions.primitives import BelongsToPractice, ObjectExists
+from app.actions.registry import register_action
+from ontology.actions._open_loop_transition import CreateLoopEffect, loop_open_reversal
+from ontology.enums.open_loop_enums import LoopKind, LoopUrgency, OpenLoopState
+
+
+@register_action
+@dataclass(eq=False)
+class OpenLoopOpen(Action):
+    """Open a new OpenLoop for a patient. The loop is born OPEN; it is
+    advanced/closed/breached by the sibling audited actions. Reversible
+    (soft-deletes the created loop)."""
+
+    __action_name__: str = "OpenLoopOpen"
+    __action_version__: int = 1
+    __reversible__: bool = True
+    __pii_level__: str = "low"
+
+    loop_id: str = ""
+    patient_id: str = ""
+    loop_kind: str = LoopKind.OTHER.value
+    opening_event_kind: str = "manual"
+    expected_closing_event_kind: str = ""
+    urgency: str = LoopUrgency.ROUTINE.value
+    deadline_at: Optional[str] = None
+    actor_user_id: str = ""
+    actor_email: Optional[str] = None
+    practice_id: str = ""
+    workspace_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.loop_id:
+            self.loop_id = str(uuid4())
+
+    def preconditions(self) -> List[Precondition]:
+        # Structural guards only. Authorization is a named PR-G addition
+        # (F-4 mechanism-vs-policy — see module docstring).
+        return [
+            ObjectExists("patients", self.patient_id),
+            BelongsToPractice("patients", self.patient_id, self.workspace_id),
+        ]
+
+    def _row(self) -> Dict[str, Any]:
+        now = datetime.now(timezone.utc).isoformat()
+        return {
+            "id": self.loop_id,
+            "workspace_id": self.workspace_id,
+            "patient_id": self.patient_id,
+            "loop_kind": self.loop_kind,
+            "state": OpenLoopState.OPEN.value,
+            "opening_event_kind": self.opening_event_kind,
+            "opening_event_ref": None,
+            "expected_closing_event_kind": self.expected_closing_event_kind,
+            "urgency": self.urgency,
+            "deadline_at": self.deadline_at,
+            "opened_at": now,
+            "closed_at": None,
+            "closed_reason": None,
+            "breached_at": None,
+        }
+
+    def effects(self) -> List[Effect]:
+        return [CreateLoopEffect(self.loop_id, self._row())]
+
+    def describe_for_user(self) -> str:
+        return (
+            f"Open a {self.loop_kind!r} loop for patient {self.patient_id} "
+            f"(closes when: {self.expected_closing_event_kind!r}). Reversible."
+        )
+
+    def to_audit_parameters(self) -> Dict[str, Any]:
+        return {
+            "loop_id": self.loop_id,
+            "patient_id": self.patient_id,
+            "loop_kind": self.loop_kind,
+            "opening_event_kind": self.opening_event_kind,
+            "expected_closing_event_kind": self.expected_closing_event_kind,
+            "urgency": self.urgency,
+            "deadline_at": self.deadline_at,
+            "actor_user_id": self.actor_user_id,
+            "practice_id": self.practice_id,
+            "workspace_id": self.workspace_id,
+        }
+
+    @classmethod
+    def from_audit_parameters(cls, params: Dict[str, Any]) -> "OpenLoopOpen":
+        return cls(
+            loop_id=params["loop_id"],
+            patient_id=params["patient_id"],
+            loop_kind=params.get("loop_kind", LoopKind.OTHER.value),
+            opening_event_kind=params.get("opening_event_kind", "manual"),
+            expected_closing_event_kind=params.get("expected_closing_event_kind", ""),
+            urgency=params.get("urgency", LoopUrgency.ROUTINE.value),
+            deadline_at=params.get("deadline_at"),
+            actor_user_id=params.get("actor_user_id", ""),
+            practice_id=params.get("practice_id", ""),
+            workspace_id=params.get("workspace_id", ""),
+        )
+
+
+register_python_reversal("OpenLoopOpen", loop_open_reversal)

--- a/backend/ontology/enums/open_loop_enums.py
+++ b/backend/ontology/enums/open_loop_enums.py
@@ -1,0 +1,90 @@
+"""
+OpenLoop ontology enums — Phase 4 PR F.
+
+The OpenLoop state machine is a CLOSED, exhaustively-tested transition
+table (F-2 locked): `OPEN → AWAITING → (CLOSED | BREACHED)`,
+`BREACHED → CLOSED`, `CLOSED` terminal. The states and the events that
+drive transitions are declared here as closed enums; the allowed-
+transition table and the transition function live in
+`ontology.objects.open_loop_state` so they can be proven non-vacuous in
+isolation BEFORE the object, migration, or actions exist (the locked
+build order).
+
+`LoopKind` is the taxonomy discriminator. F-3 (locked): PR F seeds ONLY
+kinds it can honestly back — under the F-1=B lock (substrate + state
+machine only, zero loop instance), PR F has NO detector and NO real
+instance, so the enum carries the structural-minimum value `OTHER` plus
+`SPECIALIST_REFERRAL_PENDING` as the NAMED-BUT-NOT-INSTANTIATED first
+member (its detector and lifecycle are PR-G work, F-4 locked). No other
+taxonomy kind is enumerated: an enum value with no detector and no
+honest instance is a fake-property (it asserts a capability the code
+does not have). PR G adds the remaining kinds when it builds their
+detectors — extensibility is structural (a new enum member, no migration
+churn: `open_loops.loop_kind` is TEXT, not a DB enum type).
+"""
+
+from enum import Enum
+
+
+class OpenLoopState(str, Enum):
+    """The lifecycle state of an OpenLoop. CLOSED is terminal.
+
+    OPEN      → a loop has been opened (an opening event recorded), not
+                yet acted on.
+    AWAITING  → the loop is awaiting its expected closing event (e.g. a
+                specialist letter, a result) — the deadline is live.
+    BREACHED  → the deadline passed without the closing event; the loop
+                is overdue. It is NOT terminal — it can still be closed
+                late (BREACHED → CLOSED).
+    CLOSED    → the loop is resolved (closing event arrived, or closed
+                with a reason). Terminal: no transition leaves CLOSED.
+    """
+
+    OPEN = "open"
+    AWAITING = "awaiting"
+    BREACHED = "breached"
+    CLOSED = "closed"
+
+
+class OpenLoopEvent(str, Enum):
+    """The events that drive state transitions. Each corresponds to one
+    audited action (PR F §4): ADVANCE↔OpenLoopAdvance, BREACH↔OpenLoopBreach,
+    CLOSE↔OpenLoopClose. (Opening a loop is creation, not a transition
+    from a prior state — a loop is born OPEN; there is no event into OPEN.)
+    """
+
+    ADVANCE = "advance"   # OPEN → AWAITING
+    BREACH = "breach"     # AWAITING → BREACHED
+    CLOSE = "close"       # AWAITING → CLOSED ; BREACHED → CLOSED
+
+
+class LoopUrgency(str, Enum):
+    """How time-critical this loop is. Categorical (the project's
+    enum-for-categorical discipline; a free string here would be
+    inconsistent). Two honest values for the substrate — PR G may widen
+    this WITH the detectors that would set finer urgencies; PR F does not
+    enumerate urgencies no detector assigns (the F-3 named-not-built
+    discipline applied to urgency)."""
+
+    ROUTINE = "routine"   # default; deadline matters but not time-critical
+    URGENT = "urgent"     # clinically time-critical if it breaches
+
+
+class LoopKind(str, Enum):
+    """The taxonomy discriminator. F-3 LOCKED — only honestly-backed
+    kinds are seeded here.
+
+    SPECIALIST_REFERRAL_PENDING is NAMED but NOT INSTANTIATED in PR F:
+    its detector and lifecycle are PR-G taxonomy work (F-4 locked;
+    legitimate-A carve-out only as a deliberate PR-G-merits decision).
+    OTHER is the structural-minimum value that lets the substrate be
+    coherent without enumerating kinds PR F cannot back. The remaining
+    SA-primary-care loop taxonomy (abnormal-result-unacknowledged,
+    chronic-script-expiring, immunisation-overdue, diabetic-foot-exam-due,
+    retinal-screening-due, medication-reconciliation-needed, …) is
+    PR G's to add WITH its detectors — deliberately absent here, not
+    forgotten (the PR-D Decision-2 named-not-built discipline).
+    """
+
+    SPECIALIST_REFERRAL_PENDING = "specialist_referral_pending"  # named; PR-G builds the detector
+    OTHER = "other"                                              # structural minimum

--- a/backend/ontology/links/registry.py
+++ b/backend/ontology/links/registry.py
@@ -118,6 +118,27 @@ LINKS: tuple[LinkType, ...] = (
                     "the canonical record.",
     ),
 
+    # Patient <-> OpenLoop (Phase 4 PR F) ------------------------------
+    # The ONE structural link the OpenLoop substrate intrinsically needs:
+    # every loop belongs to a patient (sourced from OpenLoop.patient_id).
+    # The opening-event link (Consultation --opened--> OpenLoop) and the
+    # closing-evidence link (Document --evidences_loop_closure-->
+    # OpenLoop) are deliberately NOT declared here: they describe how
+    # loops get opened/closed, which is detector/lifecycle work, and
+    # detectors are F-4-locked as PR G. Declaring them now would be PR-G
+    # relationships pulled into PR F for tidiness — the same anti-pattern
+    # F-1=B refuses. Named-not-built, PR G adds them WITH its detectors.
+    LinkType(
+        name="has_open_loop",
+        source_type="Patient",
+        target_type="OpenLoop",
+        cardinality=Cardinality.ONE_TO_MANY,
+        inverse_name="open_loop_for_patient",
+        description="A Patient has many OpenLoops (tracked clinical "
+                    "loops). Sourced from OpenLoop.patient_id; the "
+                    "registry makes the reverse traversal first-class.",
+    ),
+
     # MedicalAidScheme -> Patient -------------------------------------
     LinkType(
         name="covers_patient",

--- a/backend/ontology/objects/open_loop.py
+++ b/backend/ontology/objects/open_loop.py
@@ -1,0 +1,178 @@
+"""
+OpenLoop — the fourth ontology object (Phase 4 PR F).
+
+Conforms to the verified `OntologyObject` / `Prop` template
+(`ontology/base.py`): inherits the five system fields (id, practice_id,
+created_at, updated_at, deleted_at — practice_id is the ontology-level
+tenancy ref; the DB `open_loops.workspace_id` is the persistence-level
+tenancy column the RLS/PR-5-ratchet operate on, the established Patient
+split), declares ClassVar metadata, and declares domain properties via
+`Prop(...)`.
+
+F-1 = option B (LOCKED): this is the SUBSTRATE + state machine only.
+There is NO loop instance, NO detector (F-4: detectors are PR G), NO
+real corpus exercise. The object is built and its (state, *_at)
+invariant proven non-vacuous on fabricated input; the first real
+stateful loop is PR G's. The honest claim is "the state machine was
+shown to reject what it must reject", never "exercised on a real loop".
+
+The state machine itself is the closed transition table in
+`ontology.objects.open_loop_state` (built and proven to bite BEFORE this
+object — the locked build order). This object's `model_validator` is the
+SECOND, independent guard: it rejects any (state, *_at) tuple that the
+lifecycle could never legitimately produce, so an un-audited bare field
+write cannot construct a valid OpenLoop in an inconsistent state. State
+is only ever moved by an audited action (PR F §4) calling
+`apply_transition`; this validator makes the audit trail structural, not
+optional.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import ClassVar, Optional
+from uuid import UUID
+
+from pydantic import model_validator
+
+from ontology.base import OntologyObject, PIILevel, Prop, SearchBehaviour
+from ontology.enums.open_loop_enums import LoopKind, LoopUrgency, OpenLoopState
+
+
+class OpenLoop(OntologyObject):
+    """A tracked clinical loop: an opening event, an expected closing
+    event, a deadline, an urgency, and a lifecycle state. CLOSED is
+    terminal; BREACHED can still be closed late."""
+
+    __object_type_name__: ClassVar[str] = "OpenLoop"
+    __display_template__: ClassVar[str] = (
+        "OpenLoop {loop_kind} for {patient_id} ({state})"
+    )
+    # No clean FHIR analog for an internal proactive-loop tracker. Stated
+    # honestly as None — NOT mapped to an ill-fitting resource to look
+    # complete (the §C/§E "don't fake what isn't there" discipline).
+    __fhir_resource__: ClassVar[Optional[str]] = None
+    # LOW: the object holds a patient *reference* + categorical/lifecycle
+    # fields + a free-text close reason; no direct identifiers (name,
+    # dob, ID number) live here. patient_id itself is MEDIUM (it
+    # identifies which patient a loop concerns).
+    __pii_level__: ClassVar[PIILevel] = PIILevel.LOW
+    __audited__: ClassVar[bool] = True
+
+    patient_id: UUID = Prop(
+        pii=PIILevel.MEDIUM,
+        search=SearchBehaviour.FACETED,
+        display_label="Patient",
+        description="The patient this loop concerns.",
+        link_to="Patient",
+        link_cardinality="one",
+        immutable_after_create=True,
+    )
+    loop_kind: LoopKind = Prop(
+        pii=PIILevel.LOW,
+        search=SearchBehaviour.FACETED,
+        display_label="Loop kind",
+        description="Taxonomy discriminator. F-3: PR F seeds only "
+                    "honestly-backed kinds; the taxonomy is PR G's.",
+        immutable_after_create=True,
+    )
+    state: OpenLoopState = Prop(
+        pii=PIILevel.LOW,
+        search=SearchBehaviour.FACETED,
+        display_label="State",
+        description="Lifecycle state. Only ever moved by an audited "
+                    "action via the closed transition table; this "
+                    "object's model_validator rejects an inconsistent "
+                    "(state, *_at) tuple.",
+    )
+    opening_event_kind: str = Prop(
+        pii=PIILevel.LOW,
+        search=SearchBehaviour.NONE,
+        display_label="Opened by",
+        description="What opened this loop. PR F substrate has no "
+                    "detector (F-4: PR G); the only honest value here is "
+                    "'manual'. PR G's detectors set richer kinds.",
+        immutable_after_create=True,
+    )
+    opening_event_ref: Optional[str] = Prop(
+        default=None,
+        pii=PIILevel.LOW,
+        description="Optional reference to the opening event (e.g. a "
+                    "consultation id once PR G's detectors exist). "
+                    "Nullable in PR F — no detector populates it yet.",
+    )
+    expected_closing_event_kind: str = Prop(
+        pii=PIILevel.LOW,
+        search=SearchBehaviour.NONE,
+        display_label="Closes when",
+        description="A human-readable description of the event that "
+                    "would close this loop (e.g. 'specialist letter "
+                    "received'). Descriptive in PR F.",
+    )
+    urgency: LoopUrgency = Prop(
+        default=LoopUrgency.ROUTINE,
+        pii=PIILevel.LOW,
+        search=SearchBehaviour.FACETED,
+        display_label="Urgency",
+        description="How time-critical a breach is.",
+    )
+    deadline_at: Optional[datetime] = Prop(
+        default=None,
+        pii=PIILevel.LOW,
+        description="When the loop breaches if not closed. Nullable: a "
+                    "loop may have no hard deadline.",
+    )
+    opened_at: datetime = Prop(
+        pii=PIILevel.LOW,
+        description="When the loop was opened (born OPEN). Always set.",
+        immutable_after_create=True,
+    )
+    closed_at: Optional[datetime] = Prop(
+        default=None,
+        pii=PIILevel.LOW,
+        description="Set iff state == CLOSED.",
+    )
+    closed_reason: Optional[str] = Prop(
+        default=None,
+        pii=PIILevel.LOW,
+        description="Why the loop was closed. Set iff state == CLOSED.",
+    )
+    breached_at: Optional[datetime] = Prop(
+        default=None,
+        pii=PIILevel.LOW,
+        description="When the deadline was breached. Set while BREACHED "
+                    "and retained through a late BREACHED→CLOSED.",
+    )
+
+    @model_validator(mode="after")
+    def _state_at_consistency(self) -> "OpenLoop":
+        """The independent second guard (the first is the closed
+        transition table). Rejects any (state, *_at) tuple the lifecycle
+        could never legitimately produce, so a bare un-audited write
+        cannot construct a valid OpenLoop in an inconsistent state.
+
+        Decidable and exhaustive over the four states:
+          OPEN/AWAITING : not closed, not breached
+          BREACHED      : breached_at set, not closed
+          CLOSED        : closed_at + closed_reason set
+                          (breached_at MAY be set — a late BREACHED→CLOSED)
+        """
+        s = self.state
+        if s in (OpenLoopState.OPEN, OpenLoopState.AWAITING):
+            if self.closed_at is not None or self.closed_reason is not None:
+                raise ValueError(f"{s.value!r} loop must not carry closed_at/closed_reason")
+            if self.breached_at is not None:
+                raise ValueError(f"{s.value!r} loop must not carry breached_at")
+        elif s is OpenLoopState.BREACHED:
+            if self.breached_at is None:
+                raise ValueError("BREACHED loop must carry breached_at")
+            if self.closed_at is not None or self.closed_reason is not None:
+                raise ValueError("BREACHED loop must not carry closed_at/closed_reason")
+        elif s is OpenLoopState.CLOSED:
+            if self.closed_at is None or self.closed_reason is None:
+                raise ValueError("CLOSED loop must carry closed_at and closed_reason")
+            # breached_at intentionally unconstrained here: a loop closed
+            # late after a breach legitimately retains breached_at.
+        else:  # pragma: no cover - OpenLoopState is a closed enum
+            raise ValueError(f"unknown OpenLoop state {s!r}")
+        return self

--- a/backend/ontology/objects/open_loop_state.py
+++ b/backend/ontology/objects/open_loop_state.py
@@ -1,0 +1,98 @@
+"""
+OpenLoop state machine — Phase 4 PR F, THE load-bearing part, built and
+proven in isolation BEFORE the object/migration/actions (the locked
+build order; this is the one new thing in PR F and the place a §D.1
+false-green would hide).
+
+A CLOSED transition table (F-2 locked, verbatim):
+
+    OPEN     --ADVANCE--> AWAITING
+    AWAITING --BREACH-->  BREACHED
+    AWAITING --CLOSE-->   CLOSED
+    BREACHED --CLOSE-->   CLOSED
+    CLOSED   -- * -->     (terminal: nothing leaves CLOSED)
+
+Every (state, event) pair is EITHER a defined transition OR an
+explicitly-illegal one — there is NO implicit fall-through. `classify_all_pairs`
+enumerates the full state×event space so the test can assert
+completeness: a future-added state or event that is not classified makes
+the space incomplete and fails CI (F-2 rider). The transition table is
+the single source of truth; no object may change `state` except by
+`apply_transition` routed through an audited action (PR F §4) — the
+object's `model_validator` independently rejects an inconsistent
+(state, *_at) tuple so an un-audited bare write cannot produce a valid
+object.
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Dict, Tuple
+
+from ontology.enums.open_loop_enums import OpenLoopEvent, OpenLoopState
+
+ALL_STATES: Tuple[OpenLoopState, ...] = tuple(OpenLoopState)
+ALL_EVENTS: Tuple[OpenLoopEvent, ...] = tuple(OpenLoopEvent)
+
+# The closed transition table (F-2 locked). A (state, event) key present
+# here is the ONLY way that pair is legal; its value is the resulting
+# state. Absence = explicitly illegal (no fall-through).
+ALLOWED_TRANSITIONS: Dict[Tuple[OpenLoopState, OpenLoopEvent], OpenLoopState] = {
+    (OpenLoopState.OPEN, OpenLoopEvent.ADVANCE): OpenLoopState.AWAITING,
+    (OpenLoopState.AWAITING, OpenLoopEvent.BREACH): OpenLoopState.BREACHED,
+    (OpenLoopState.AWAITING, OpenLoopEvent.CLOSE): OpenLoopState.CLOSED,
+    (OpenLoopState.BREACHED, OpenLoopEvent.CLOSE): OpenLoopState.CLOSED,
+}
+
+# Terminal states have zero outgoing legal transitions. Derived from the
+# table (not asserted independently) so it cannot drift from it.
+TERMINAL_STATES: Tuple[OpenLoopState, ...] = tuple(
+    s for s in ALL_STATES
+    if not any(k[0] == s for k in ALLOWED_TRANSITIONS)
+)
+
+
+class IllegalLoopTransition(ValueError):
+    """Raised when an (state, event) pair is not in the closed table.
+
+    A ValueError subclass so the object's `model_validator` and the
+    audited action's precondition can both treat an illegal transition
+    as the same rejection.
+    """
+
+    def __init__(self, state: OpenLoopState, event: OpenLoopEvent) -> None:
+        super().__init__(
+            f"illegal OpenLoop transition: no {event.value!r} from "
+            f"{state.value!r} (closed transition table; CLOSED is terminal)"
+        )
+        self.state = state
+        self.event = event
+
+
+def apply_transition(state: OpenLoopState, event: OpenLoopEvent) -> OpenLoopState:
+    """Return the resulting state for a legal (state, event), else raise
+    IllegalLoopTransition. The ONLY sanctioned way to move state."""
+    try:
+        return ALLOWED_TRANSITIONS[(state, event)]
+    except KeyError:
+        raise IllegalLoopTransition(state, event) from None
+
+
+def classify_all_pairs() -> Dict[Tuple[OpenLoopState, OpenLoopEvent], str]:
+    """Classify EVERY (state, event) pair in the full state×event space
+    as 'defined' or 'illegal' — exhaustively, no pair unclassified.
+
+    This is the completeness oracle the test uses: it iterates the
+    cartesian product of the live enums, so adding a state or an event
+    without updating ALLOWED_TRANSITIONS still yields a fully-classified
+    map (the new pairs land in 'illegal'); the test then asserts that
+    the count of 'defined' equals len(ALLOWED_TRANSITIONS) and that the
+    map covers exactly |states|×|events| pairs — so an unhandled pair or
+    a stale table is a build failure, never a silent fall-through.
+    """
+    out: Dict[Tuple[OpenLoopState, OpenLoopEvent], str] = {}
+    for state, event in product(ALL_STATES, ALL_EVENTS):
+        out[(state, event)] = (
+            "defined" if (state, event) in ALLOWED_TRANSITIONS else "illegal"
+        )
+    return out

--- a/backend/tests/test_open_loop_actions.py
+++ b/backend/tests/test_open_loop_actions.py
@@ -1,0 +1,212 @@
+"""
+OpenLoop audited actions — DB-free suite (Phase 4 PR F).
+
+The full executor round-trip (execute() → action_audit_log → reverse())
+is RUN_INTEGRATION (needs the migrated DB; the user's Dashboard step).
+This suite proves, WITHOUT a DB, the parts that can be proven without
+one and where a bug would hide:
+
+  * registration + the SoftDeletePatient-analog structure,
+  * the transition EFFECT computes the correct next state + before-image,
+  * the reversal builder produces an inverse that restores the LITERAL
+    prior values — round-trip, and **path-independent** for CLOSE
+    (AWAITING→CLOSED vs BREACHED→CLOSED both reverse exactly),
+  * the effect-layer SECOND structural guard (apply_transition) rejects
+    an illegal source even if a precondition were bypassed.
+
+Non-vacuity (F-1 rider, action layer): the reversal assertions prove the
+inverse actually ran and restored the exact prior — a no-op reversal
+would leave the mutated state and fail. A fake in-memory supabase backs
+the effects; no network, no Supabase.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from app.actions.base import ActorContext, ExecutorContext
+from app.actions.executor import _REVERSE_PYTHON_FOR_ACTION
+from ontology.actions._open_loop_transition import (
+    CreateLoopEffect,
+    LoopTransitionEffect,
+    loop_open_reversal,
+    loop_transition_reversal,
+)
+from ontology.actions.open_loop_advance import OpenLoopAdvance
+from ontology.actions.open_loop_breach import OpenLoopBreach
+from ontology.actions.open_loop_close import OpenLoopClose
+from ontology.actions.open_loop_open import OpenLoopOpen
+from ontology.enums.open_loop_enums import OpenLoopEvent
+
+
+# ---- minimal in-memory fake supabase (only what the effects use) ------
+
+class _Resp:
+    def __init__(self, data): self.data = data
+
+
+class _Q:
+    def __init__(self, store, table):
+        self._store, self._table = store, table
+        self._where: Dict[str, Any] = {}
+        self._pending_update: Optional[Dict[str, Any]] = None
+
+    def select(self, *_a, **_k): return self
+    def insert(self, row): self._store.setdefault(self._table, {})[row["id"]] = dict(row); return self
+    def update(self, d): self._pending_update = dict(d); return self
+
+    def eq(self, col, val):
+        self._where[col] = val
+        return self
+
+    def execute(self):
+        rows = list(self._store.get(self._table, {}).values())
+        for c, v in self._where.items():
+            rows = [r for r in rows if r.get(c) == v]
+        if self._pending_update is not None:
+            for r in rows:
+                r.update(self._pending_update)
+            return _Resp(rows)
+        return _Resp([dict(r) for r in rows])
+
+
+class _FakeSupabase:
+    def __init__(self): self.store: Dict[str, Dict[str, dict]] = {}
+    def table(self, name): return _Q(self.store, name)
+
+
+def _ctx(fake):
+    return ExecutorContext(
+        supabase=fake,
+        actor=ActorContext(user_id="u1", email="u1@x.com", permissions=[]),
+        practice_id="demo-briefing-workspace-001",
+        workspace_id="demo-briefing-workspace-001",
+    )
+
+
+def _seed_loop(fake, **fields):
+    base = dict(
+        id="loop-1", workspace_id="demo-briefing-workspace-001",
+        patient_id="pat-1", loop_kind="other", state="open",
+        opening_event_kind="manual", opening_event_ref=None,
+        expected_closing_event_kind="specialist letter", urgency="routine",
+        deadline_at=None, opened_at="2026-05-17T09:00:00+00:00",
+        closed_at=None, closed_reason=None, breached_at=None,
+        created_at="2026-05-17T09:00:00+00:00",
+        updated_at="2026-05-17T09:00:00+00:00", deleted_at=None,
+    )
+    base.update(fields)
+    fake.store.setdefault("open_loops", {})[base["id"]] = base
+
+
+def _audit_from(er) -> Dict[str, Any]:
+    """Shape the executor would persist: effects_applied[i].result =
+    EffectResult.to_dict() (the verified audit-row shape)."""
+    return {"effects_applied": [{"name": er.name, "result": er.to_dict()}]}
+
+
+# ---- registration + structure (the SoftDeletePatient analog) ----------
+
+@pytest.mark.parametrize("name", [
+    "OpenLoopOpen", "OpenLoopAdvance", "OpenLoopBreach", "OpenLoopClose",
+])
+def test_actions_register_python_reversal(name):
+    assert name in _REVERSE_PYTHON_FOR_ACTION
+
+
+def test_action_dunders_and_audit_param_roundtrip():
+    for cls, name in [
+        (OpenLoopOpen, "OpenLoopOpen"), (OpenLoopAdvance, "OpenLoopAdvance"),
+        (OpenLoopBreach, "OpenLoopBreach"), (OpenLoopClose, "OpenLoopClose"),
+    ]:
+        a = cls(loop_id="loop-1", workspace_id="ws", actor_user_id="u1")
+        assert a.__action_name__ == name
+        assert a.__reversible__ is True
+        rt = cls.from_audit_parameters(a.to_audit_parameters())
+        assert rt.loop_id == "loop-1"
+        assert isinstance(a.preconditions(), list) and a.preconditions()
+        assert isinstance(a.effects(), list) and a.effects()
+
+
+def test_close_precondition_accepts_both_legal_sources():
+    pcs = OpenLoopClose(loop_id="loop-1", workspace_id="ws").preconditions()
+    son = [p for p in pcs if p.__class__.__name__ == "StatusOneOf"]
+    assert son and sorted(son[0].allowed) == ["awaiting", "breached"]
+
+
+# ---- effect transition + before-image + reversal round-trip -----------
+
+def test_advance_effect_transitions_and_reversal_restores_exactly():
+    fake = _FakeSupabase(); _seed_loop(fake, state="open")
+    er = LoopTransitionEffect("loop-1", OpenLoopEvent.ADVANCE).apply(_ctx(fake))
+    assert er.succeeded
+    assert fake.store["open_loops"]["loop-1"]["state"] == "awaiting"
+
+    before = json.loads(er.detail)["before"]
+    assert before["state"] == "open"  # the literal prior recorded
+
+    rev_effects = loop_transition_reversal(_audit_from(er), None)
+    assert len(rev_effects) == 1  # non-vacuous: a real inverse was built
+    rev_effects[0].apply(_ctx(fake))
+    assert fake.store["open_loops"]["loop-1"]["state"] == "open"  # restored exactly
+
+
+def test_close_is_path_independent__awaiting_vs_breached_both_reverse_exactly():
+    # AWAITING → CLOSED → reverse → AWAITING (closed_* back to None)
+    fa = _FakeSupabase(); _seed_loop(fa, state="awaiting")
+    er_a = LoopTransitionEffect("loop-1", OpenLoopEvent.CLOSE,
+                                closed_reason="resolved").apply(_ctx(fa))
+    assert fa.store["open_loops"]["loop-1"]["state"] == "closed"
+    loop_transition_reversal(_audit_from(er_a), None)[0].apply(_ctx(fa))
+    row_a = fa.store["open_loops"]["loop-1"]
+    assert row_a["state"] == "awaiting"
+    assert row_a["closed_at"] is None and row_a["closed_reason"] is None
+
+    # BREACHED → CLOSED → reverse → BREACHED (breached_at intact)
+    fb = _FakeSupabase()
+    _seed_loop(fb, state="breached", breached_at="2026-05-20T09:00:00+00:00")
+    er_b = LoopTransitionEffect("loop-1", OpenLoopEvent.CLOSE,
+                                closed_reason="late close").apply(_ctx(fb))
+    assert fb.store["open_loops"]["loop-1"]["state"] == "closed"
+    loop_transition_reversal(_audit_from(er_b), None)[0].apply(_ctx(fb))
+    row_b = fb.store["open_loops"]["loop-1"]
+    assert row_b["state"] == "breached"
+    assert row_b["breached_at"] == "2026-05-20T09:00:00+00:00"
+    assert row_b["closed_at"] is None and row_b["closed_reason"] is None
+
+
+def test_effect_layer_second_guard_rejects_illegal_source():
+    """Defense in depth: even if a precondition were bypassed, the
+    effect calling apply_transition rejects an illegal (state,event)."""
+    fake = _FakeSupabase(); _seed_loop(fake, state="closed")
+    er = LoopTransitionEffect("loop-1", OpenLoopEvent.ADVANCE).apply(_ctx(fake))
+    assert er.succeeded is False
+    assert er.error is not None
+    assert "illegal OpenLoop transition" in er.error.message
+    # the row was NOT mutated by a rejected effect
+    assert fake.store["open_loops"]["loop-1"]["state"] == "closed"
+
+
+def test_reversal_with_no_before_image_is_explicit_noop():
+    assert loop_transition_reversal({"effects_applied": []}, None) == []
+    assert loop_transition_reversal({}, None) == []
+
+
+def test_create_effect_and_open_reversal_soft_deletes_created():
+    fake = _FakeSupabase()
+    row = OpenLoopOpen(
+        loop_id="loop-9", patient_id="pat-1",
+        workspace_id="demo-briefing-workspace-001",
+        expected_closing_event_kind="x",
+    )._row()
+    er = CreateLoopEffect("loop-9", row).apply(_ctx(fake))
+    assert er.succeeded
+    assert fake.store["open_loops"]["loop-9"]["state"] == "open"
+
+    rev = loop_open_reversal(_audit_from(er), None)
+    assert len(rev) == 1
+    assert rev[0].__class__.__name__ == "SoftDelete"
+    assert rev[0].object_id == "loop-9" and rev[0].table == "open_loops"

--- a/backend/tests/test_open_loop_executor_roundtrip.py
+++ b/backend/tests/test_open_loop_executor_roundtrip.py
@@ -1,0 +1,184 @@
+"""
+OpenLoop executor round-trip — RUN_INTEGRATION (Phase 4 PR F).
+
+Skipped unless RUN_INTEGRATION is set (writes to the live DB:
+opens/advances/closes/reverses ONE fabricated loop in a real workspace,
+then removes it and asserts the workspace is back to baseline). This is
+the verification the DB-free suite structurally proved + proved-to-bite
+but could not exercise: the real round-trip against the real executor
+and the real action_audit_log.
+
+Reports ACTUALS via psycopg2 read-back (the PR-D idiom), and the
+teardown ASSERTS cleanup (the PR-D teardown-non-vacuity discipline —
+the fabricated loop actually gone, the workspace's open_loops back to
+the captured baseline), it does not assume it.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("RUN_INTEGRATION"),
+    reason="RUN_INTEGRATION not set (writes to the live DB)",
+)
+
+
+def _supabase():
+    from supabase import create_client
+
+    url = os.environ["SUPABASE_URL"]
+    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ["SUPABASE_KEY"]
+    return create_client(url, key)
+
+
+def _pg():
+    import psycopg2
+
+    return psycopg2.connect(os.environ["DATABASE_URL"])
+
+
+def test_open_loop_executor_roundtrip_and_reversal():
+    import app.actions.registered  # noqa: F401  (fires @register_action)
+    from app.actions.base import ActorContext
+    from app.actions.executor import execute, reverse
+    from ontology.actions.open_loop_advance import OpenLoopAdvance
+    from ontology.actions.open_loop_close import OpenLoopClose
+    from ontology.actions.open_loop_open import OpenLoopOpen
+
+    sb = _supabase()
+    actor = ActorContext(user_id="integration-test", email="it@x.com", permissions=[])
+
+    # --- pick a real patient in a real workspace (the Open precondition) ---
+    conn = _pg()
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, workspace_id FROM patients "
+        "WHERE workspace_id IN ('demo-gp-workspace-001','demo-briefing-workspace-001') "
+        "AND deleted_at IS NULL LIMIT 1"
+    )
+    prow = cur.fetchone()
+    assert prow is not None, "no usable patient found in demo workspaces"
+    patient_id, ws = str(prow[0]), prow[1]
+
+    cur.execute("SELECT count(*) FROM open_loops WHERE workspace_id=%s", (ws,))
+    baseline = cur.fetchone()[0]
+    print(f"\nACTUALS — workspace={ws} patient={patient_id} "
+          f"open_loops baseline={baseline}")
+
+    loop_id = str(uuid.uuid4())
+    audit_ids = []
+    try:
+        # 1. OPEN -------------------------------------------------------
+        r_open = execute(
+            OpenLoopOpen(
+                loop_id=loop_id, patient_id=patient_id,
+                expected_closing_event_kind="specialist letter received",
+                actor_user_id=actor.user_id, practice_id=ws, workspace_id=ws,
+            ),
+            actor=actor, supabase=sb, practice_id=ws, workspace_id=ws,
+        )
+        audit_ids.append(r_open.audit_id)
+        cur.execute("SELECT state FROM open_loops WHERE id=%s", (loop_id,))
+        st_open = cur.fetchone()
+        cur.execute("SELECT count(*) FROM action_audit_log WHERE id=%s",
+                    (r_open.audit_id,))
+        open_audit_n = cur.fetchone()[0]
+        print(f"OPEN    -> outcome={r_open.outcome!r} "
+              f"open_loops.state={st_open and st_open[0]!r} "
+              f"audit_row_present={open_audit_n}")
+        assert r_open.outcome == "success"
+        assert st_open and st_open[0] == "open"
+        assert open_audit_n == 1
+
+        # 2. ADVANCE ----------------------------------------------------
+        r_adv = execute(
+            OpenLoopAdvance(loop_id=loop_id, actor_user_id=actor.user_id,
+                            practice_id=ws, workspace_id=ws),
+            actor=actor, supabase=sb, practice_id=ws, workspace_id=ws,
+        )
+        audit_ids.append(r_adv.audit_id)
+        cur.execute("SELECT state FROM open_loops WHERE id=%s", (loop_id,))
+        st_adv = cur.fetchone()[0]
+        print(f"ADVANCE -> outcome={r_adv.outcome!r} open_loops.state={st_adv!r}")
+        assert r_adv.outcome == "success"
+        assert st_adv == "awaiting"
+
+        # 3. CLOSE ------------------------------------------------------
+        r_close = execute(
+            OpenLoopClose(loop_id=loop_id, closed_reason="integration round-trip",
+                          actor_user_id=actor.user_id, practice_id=ws,
+                          workspace_id=ws),
+            actor=actor, supabase=sb, practice_id=ws, workspace_id=ws,
+        )
+        audit_ids.append(r_close.audit_id)
+        cur.execute(
+            "SELECT state, closed_at, closed_reason FROM open_loops WHERE id=%s",
+            (loop_id,),
+        )
+        st_c, c_at, c_reason = cur.fetchone()
+        print(f"CLOSE   -> outcome={r_close.outcome!r} state={st_c!r} "
+              f"closed_at_set={c_at is not None} closed_reason={c_reason!r}")
+        assert r_close.outcome == "success"
+        assert st_c == "closed" and c_at is not None
+        assert c_reason == "integration round-trip"
+
+        # 4. REVERSE the close -----------------------------------------
+        r_rev = reverse(r_close.audit_id, actor=actor, supabase=sb)
+        audit_ids.append(r_rev.audit_id)
+        cur.execute(
+            "SELECT reversed_by_audit_id FROM action_audit_log WHERE id=%s",
+            (r_close.audit_id,),
+        )
+        reversed_by = cur.fetchone()[0]
+        cur.execute(
+            "SELECT reverses_audit_id, outcome FROM action_audit_log WHERE id=%s",
+            (r_rev.audit_id,),
+        )
+        reverses, rev_outcome = cur.fetchone()
+        cur.execute(
+            "SELECT state, closed_at, closed_reason FROM open_loops WHERE id=%s",
+            (loop_id,),
+        )
+        st_r, c_at_r, c_reason_r = cur.fetchone()
+        print(f"REVERSE -> outcome={r_rev.outcome!r} "
+              f"orig.reversed_by={str(reversed_by)!r} "
+              f"rev.reverses={str(reverses)!r} rev.row_outcome={rev_outcome!r}")
+        print(f"        -> before-image restored: state={st_r!r} "
+              f"closed_at={c_at_r} closed_reason={c_reason_r!r}")
+        assert r_rev.outcome == "reversed"
+        assert str(reversed_by) == str(r_rev.audit_id)       # wiring, real rows
+        assert str(reverses) == str(r_close.audit_id)        # wiring, real rows
+        assert st_r == "awaiting"                            # before-image
+        assert c_at_r is None and c_reason_r is None         # before-image
+    finally:
+        # --- teardown: REMOVE the fabricated rows, ASSERT it worked ---
+        # The close row and its reversal row form an FK cycle
+        # (reverses_audit_id <-> reversed_by_audit_id). Break BOTH FK
+        # columns on every collected row first, THEN delete — order- and
+        # cycle-independent.
+        with conn.cursor() as tc:
+            tc.execute("DELETE FROM open_loops WHERE id=%s", (loop_id,))
+            for aid in audit_ids:
+                tc.execute(
+                    "UPDATE action_audit_log "
+                    "SET reverses_audit_id=NULL, reversed_by_audit_id=NULL "
+                    "WHERE id=%s",
+                    (aid,),
+                )
+            for aid in audit_ids:
+                tc.execute("DELETE FROM action_audit_log WHERE id=%s", (aid,))
+        cur.execute("SELECT count(*) FROM open_loops WHERE id=%s", (loop_id,))
+        loop_gone = cur.fetchone()[0] == 0
+        cur.execute("SELECT count(*) FROM open_loops WHERE workspace_id=%s", (ws,))
+        post = cur.fetchone()[0]
+        print(f"CLEANUP -> fabricated loop gone={loop_gone} "
+              f"open_loops[{ws}] back to baseline={post == baseline} "
+              f"({post} vs {baseline})")
+        conn.close()
+        assert loop_gone, "teardown did NOT remove the fabricated loop"
+        assert post == baseline, "workspace open_loops not restored to baseline"

--- a/backend/tests/test_open_loop_object.py
+++ b/backend/tests/test_open_loop_object.py
@@ -1,0 +1,135 @@
+"""
+OpenLoop object — the SECOND, independent guard test (Phase 4 PR F).
+
+The closed transition table (test_open_loop_state_machine.py) is the
+first guard. This proves the object's `model_validator` is the second,
+independent one: it rejects any (state, *_at) tuple the lifecycle could
+never legitimately produce, so a bare un-audited field write cannot
+construct a valid OpenLoop in an inconsistent state.
+
+Same non-vacuity discipline as the state-machine suite (F-1 rider): the
+invalid-rejection half is load-bearing; this file counts its rejection
+assertions and asserts the count is non-zero — a suite that only builds
+valid objects is the §D.1 false-green relocated and cannot pass.
+
+DB-free: pure Pydantic construction, no Supabase/network.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from ontology.enums.open_loop_enums import LoopKind, LoopUrgency, OpenLoopState
+from ontology.objects.open_loop import OpenLoop
+
+NOW = datetime(2026, 5, 17, 9, 0, tzinfo=timezone.utc)
+LATER = datetime(2026, 5, 24, 9, 0, tzinfo=timezone.utc)
+
+
+def _base(**overrides):
+    """Minimum valid kwargs for an OPEN loop; overrides tune state/*_at."""
+    kw = dict(
+        id=uuid4(),
+        practice_id="demo-briefing-workspace-001",
+        created_at=NOW,
+        updated_at=NOW,
+        patient_id=uuid4(),
+        loop_kind=LoopKind.OTHER,
+        state=OpenLoopState.OPEN,
+        opening_event_kind="manual",
+        expected_closing_event_kind="specialist letter received",
+        urgency=LoopUrgency.ROUTINE,
+        opened_at=NOW,
+    )
+    kw.update(overrides)
+    return kw
+
+
+# ---- valid (state, *_at) tuples — every legitimate lifecycle shape ----
+
+def test_valid_states_construct():
+    OpenLoop(**_base(state=OpenLoopState.OPEN))
+    OpenLoop(**_base(state=OpenLoopState.AWAITING))
+    OpenLoop(**_base(state=OpenLoopState.BREACHED, breached_at=LATER))
+    OpenLoop(**_base(
+        state=OpenLoopState.CLOSED, closed_at=LATER, closed_reason="resolved"
+    ))
+
+
+def test_closed_after_breach_retains_breached_at__explicit_valid_fact():
+    """A loop closed late after a breach legitimately carries BOTH
+    breached_at and closed_at with state CLOSED — an explicit allowed
+    shape, not the absence of a check."""
+    OpenLoop(**_base(
+        state=OpenLoopState.CLOSED,
+        breached_at=LATER,
+        closed_at=LATER,
+        closed_reason="closed late after breach",
+    ))
+
+
+# ---- THE load-bearing half: inconsistent tuples are REJECTED ----------
+
+INVALID_CASES = [
+    ("OPEN + closed_at", dict(state=OpenLoopState.OPEN, closed_at=LATER)),
+    ("OPEN + closed_reason", dict(state=OpenLoopState.OPEN, closed_reason="x")),
+    ("OPEN + breached_at", dict(state=OpenLoopState.OPEN, breached_at=LATER)),
+    ("AWAITING + closed_at", dict(state=OpenLoopState.AWAITING, closed_at=LATER)),
+    ("AWAITING + breached_at", dict(state=OpenLoopState.AWAITING, breached_at=LATER)),
+    ("BREACHED w/o breached_at", dict(state=OpenLoopState.BREACHED)),
+    ("BREACHED + closed_at", dict(
+        state=OpenLoopState.BREACHED, breached_at=LATER, closed_at=LATER,
+        closed_reason="x")),
+    ("CLOSED w/o closed_at", dict(
+        state=OpenLoopState.CLOSED, closed_reason="x")),
+    ("CLOSED w/o closed_reason", dict(
+        state=OpenLoopState.CLOSED, closed_at=LATER)),
+]
+
+
+@pytest.mark.parametrize("label,override", INVALID_CASES, ids=[c[0] for c in INVALID_CASES])
+def test_inconsistent_state_at_tuple_is_rejected(label, override):
+    """Each lifecycle-impossible (state, *_at) tuple must raise — this is
+    the validator being the independent second guard against an
+    un-audited bare write."""
+    with pytest.raises(ValidationError):
+        OpenLoop(**_base(**override))
+
+
+def test_rejection_suite_is_non_vacuous():
+    """F-1 non-vacuity rider, object layer: prove the invalid-rejection
+    half actually ran over every invalid case (a valid-only suite would
+    leave this at zero and fail)."""
+    rejections = 0
+    for _label, override in INVALID_CASES:
+        with pytest.raises(ValidationError):
+            OpenLoop(**_base(**override))
+        rejections += 1
+    assert rejections > 0
+    assert rejections == len(INVALID_CASES)
+
+
+def test_bare_write_to_closed_without_closed_at_cannot_construct():
+    """The explicit 'no un-audited bare write' fact: setting state=CLOSED
+    without the closing fields (what a raw UPDATE bypassing the audited
+    action would do) cannot produce a valid object."""
+    with pytest.raises(ValidationError):
+        OpenLoop(**_base(state=OpenLoopState.CLOSED))
+
+
+def test_object_is_registered_and_conforms_to_template():
+    """OpenLoop is wired the same way as Patient/Document/Consultation."""
+    from ontology import OpenLoop as ExportedOpenLoop
+    assert ExportedOpenLoop is OpenLoop
+    assert OpenLoop.__object_type_name__ == "OpenLoop"
+    assert OpenLoop.__fhir_resource__ is None  # stated, not faked
+    assert OpenLoop.__audited__ is True
+    # inherits the five system fields from OntologyObject
+    for f in ("id", "practice_id", "created_at", "updated_at", "deleted_at"):
+        assert f in OpenLoop.model_fields
+    # the Patient->OpenLoop link is registered
+    from ontology.links.registry import find_link
+    link = find_link("Patient", "OpenLoop", "has_open_loop")
+    assert link is not None and link.inverse_name == "open_loop_for_patient"

--- a/backend/tests/test_open_loop_state_machine.py
+++ b/backend/tests/test_open_loop_state_machine.py
@@ -1,0 +1,132 @@
+"""
+The OpenLoop state-machine non-vacuity suite — Phase 4 PR F, THE
+load-bearing test, built and proven to BITE before the object,
+migration, or actions exist (the locked build order).
+
+F-1 non-vacuity rider (LOCKED, the §D.1 mechanism, verbatim): these are
+"construct-validity tests proven non-vacuous by asserted rejection of
+illegal transitions." The illegal-rejection half is load-bearing. A
+suite that only feeds legal fabricated transitions is the §D.1
+false-green relocated and is explicitly disallowed — so this file
+*counts* its illegal-rejection assertions and asserts that the count is
+non-zero AND equals the full count of illegal pairs in the state×event
+space. A legal-only version of this suite cannot pass.
+
+F-2 rider (LOCKED): the table is closed and exhaustively tested over the
+full state×event space; no implicit fall-through; an unhandled pair (a
+future-added state/event not in the table) fails CI; `BREACHED→CLOSED`
+and `CLOSED→*`-rejected are explicit asserted facts, not the absence of
+code.
+
+DB-free: pure transition logic, no Supabase/Pydantic/network.
+"""
+
+from itertools import product
+
+import pytest
+
+from ontology.enums.open_loop_enums import OpenLoopEvent, OpenLoopState
+from ontology.objects.open_loop_state import (
+    ALL_EVENTS,
+    ALL_STATES,
+    ALLOWED_TRANSITIONS,
+    TERMINAL_STATES,
+    IllegalLoopTransition,
+    apply_transition,
+    classify_all_pairs,
+)
+
+S = OpenLoopState
+E = OpenLoopEvent
+
+# The EXACT locked F-2 table, written out independently of the module so
+# a drift in ALLOWED_TRANSITIONS (added/removed/changed transition) is
+# caught here, not silently inherited.
+LOCKED_LEGAL = {
+    (S.OPEN, E.ADVANCE): S.AWAITING,
+    (S.AWAITING, E.BREACH): S.BREACHED,
+    (S.AWAITING, E.CLOSE): S.CLOSED,
+    (S.BREACHED, E.CLOSE): S.CLOSED,
+}
+
+
+def test_table_is_exactly_the_locked_F2_set():
+    """Drift guard: the module's table must be EXACTLY the 4 locked
+    transitions — no more (scope creep), no fewer (regression)."""
+    assert ALLOWED_TRANSITIONS == LOCKED_LEGAL
+
+
+def test_state_event_space_fully_classified_no_fall_through():
+    """F-2 completeness/CI bite: every (state,event) pair in the live
+    enum product is classified 'defined' or 'illegal' — exhaustively,
+    once each, nothing unhandled. A future-added state/event not in the
+    table still classifies (as 'illegal'); this test additionally pins
+    the defined-count to the locked table so a stale table fails."""
+    classified = classify_all_pairs()
+    full_space = set(product(ALL_STATES, ALL_EVENTS))
+    assert set(classified.keys()) == full_space
+    assert len(classified) == len(ALL_STATES) * len(ALL_EVENTS)
+    defined = [p for p, c in classified.items() if c == "defined"]
+    illegal = [p for p, c in classified.items() if c == "illegal"]
+    assert set(classified.values()) <= {"defined", "illegal"}  # no third class / no unhandled
+    assert len(defined) == len(LOCKED_LEGAL)
+    assert len(defined) + len(illegal) == len(full_space)
+
+
+def test_legal_transitions_execute_to_expected_state():
+    """Every locked-legal pair: apply_transition produces the expected
+    next state."""
+    for (state, event), expected in LOCKED_LEGAL.items():
+        assert apply_transition(state, event) is expected
+
+
+def test_illegal_transitions_are_rejected__and_the_rejection_count_proves_non_vacuity():
+    """THE load-bearing assertion (F-1 non-vacuity rider). Every pair in
+    the FULL state×event space that is NOT a locked-legal transition is
+    fed in and asserted to RAISE. The number of rejections actually
+    executed is counted and asserted to (a) be > 0 and (b) equal the
+    exact count of illegal pairs — so a legal-only suite (0 rejections)
+    structurally cannot pass this test."""
+    full_space = list(product(ALL_STATES, ALL_EVENTS))
+    illegal_pairs = [p for p in full_space if p not in LOCKED_LEGAL]
+
+    rejections_executed = 0
+    for state, event in illegal_pairs:
+        with pytest.raises(IllegalLoopTransition) as ei:
+            apply_transition(state, event)
+        # the raised error carries the offending pair (used by the
+        # object validator + action precondition the same way)
+        assert ei.value.state is state
+        assert ei.value.event is event
+        rejections_executed += 1
+
+    assert rejections_executed > 0, "vacuous: no illegal transition was exercised"
+    assert rejections_executed == len(full_space) - len(LOCKED_LEGAL)
+    assert rejections_executed == len(illegal_pairs)
+
+
+def test_breached_can_still_close__explicit_fact():
+    """`BREACHED → CLOSE → CLOSED` is an explicit allowed fact (a
+    breached loop can still be resolved late), not the absence of code."""
+    assert apply_transition(S.BREACHED, E.CLOSE) is S.CLOSED
+
+
+def test_closed_is_terminal__every_event_rejected_explicitly():
+    """CLOSED is terminal: every event from CLOSED is an explicit
+    asserted rejection, not merely 'no code for it'."""
+    for event in ALL_EVENTS:
+        with pytest.raises(IllegalLoopTransition):
+            apply_transition(S.CLOSED, event)
+    assert S.CLOSED in TERMINAL_STATES
+    assert TERMINAL_STATES == (S.CLOSED,)  # CLOSED is the ONLY terminal state
+
+
+def test_open_cannot_close_directly__locked_table_has_no_OPEN_to_CLOSED():
+    """The locked F-2 table is `OPEN → AWAITING → (CLOSED|BREACHED)`;
+    there is deliberately NO direct OPEN→CLOSED. Asserted as an explicit
+    fact so a future 'shortcut' is a deliberate F-2 override, not a
+    silent addition."""
+    with pytest.raises(IllegalLoopTransition):
+        apply_transition(S.OPEN, E.CLOSE)
+    with pytest.raises(IllegalLoopTransition):
+        apply_transition(S.OPEN, E.BREACH)

--- a/backend/tests/test_tenant_query_isolation.py
+++ b/backend/tests/test_tenant_query_isolation.py
@@ -89,6 +89,15 @@ TENANT_TABLES: Set[str] = {
     # new BASELINE keys — a new tenant table joins the scanned set
     # born-scoped, the ratchet doing its job (it only goes down).
     "briefing_items",
+    # PR F: OpenLoop substrate. RLS-deny-all (migration 028, the 018
+    # idiom verbatim). Under F-1=B the only writes are via the existing
+    # audited Effect primitives, which use `.table(self.table)` (a
+    # variable, NOT a string literal) and scope by row id through the
+    # executor — so the static scanner finds ZERO `.table("open_loops")`
+    # string-literal chains and adding it here adds ZERO new BASELINE
+    # keys: born tenant-scoped, the ratchet only goes down. (Verified by
+    # running test_no_new_unscoped_tenant_queries, not asserted.)
+    "open_loops",
 }
 
 # Predicates that count as a tenant scope on a query chain. First-arg


### PR DESCRIPTION
## Phase 4 — PR F: `OpenLoop` substrate (object + closed non-vacuous state machine + audited reversible actions)

**F-1 = option B (locked):** substrate + state machine + audited mutation
actions ONLY. No detector, no real loop instance — the first real
stateful loop is **PR G's**. The umbrella's "refactor existing follow-up
logic" premise was **falsified at file:line** (every existing mechanism
is a stateless recomputed cohort or write-once-inert) and recorded as
the §2.0 §D.1-class note: **PR F is an introduction, not a refactor.**

### What landed
- **Closed transition table** (`open_loop_state.py`), F-2 verbatim:
  `OPEN→AWAITING→(CLOSED|BREACHED)`, `BREACHED→CLOSED`, `CLOSED`
  terminal. Built **first**; its non-vacuity test **proven to bite** by
  fault injection (3 illegal-rejection tests RED, legal/structure green;
  a legal-only suite structurally cannot pass).
- **`OpenLoop` object** — conforms to the verified `OntologyObject`/`Prop`
  template; `model_validator` is the independent second guard, proven to
  bite (no-op → 11 RED). `Patient--has_open_loop-->OpenLoop` registered.
- **4 audited reversible actions** (Open/Advance/Breach/Close) through
  the existing `ActionExecutor`, Python before-image reversal mirroring
  the `SoftDeletePatient` analog. Authorization deferred to PR G (F-4
  mechanism-vs-policy), named not guessed.
- **Migration 028** — `open_loops`; migration-018 RLS deny-all idiom
  verbatim; 027-style decided NOTIFY; `loop_kind`/`state`/`urgency`
  TEXT-not-enum (F-3 structural extensibility). Added to PR-5
  `TENANT_TABLES`; ratchet green, **zero new BASELINE keys (verified by
  running it)**.

### Verification
- 32 DB-free tests green + tenant ratchet + 151-test collection clean.
- **Round-trip-exercised** against the real executor + `action_audit_log`
  + reversal: `OPEN→ADVANCE→CLOSE→REVERSE`, before-image restoration and
  bidirectional `reversed_by`/`reverses` wiring verified by psycopg2
  read-back, cleanup asserted to baseline.

### The scar, kept legible (not squashed)
The RUN_INTEGRATION round-trip's **first run failed in the test's
teardown — not the round-trip** (the round-trip was correct and
independently corroborated by the live `action_audit_log`). The naive
delete order hit the deliberate `action_audit_log` close↔reversal FK
cycle and left **2 orphaned audit rows in the live demo workspace** —
treated as a real harm (audit-log pollution in a clinical
source-of-truth table), reported before interpretation, cleaned
FK-correct scoped to the two ids, residue verified zero, teardown
permanently fixed (cycle-safe), re-run clean. **§5.1 records the
FK-cycle teardown idiom as inherited knowledge for PR G's audit-row
cleanup.** The failure-and-honest-recovery is the credential, the
seventh time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
